### PR TITLE
fix preview_template params arg passing

### DIFF
--- a/dnacentersdk/api/v1_2_10/template_programmer.py
+++ b/dnacentersdk/api/v1_2_10/template_programmer.py
@@ -981,6 +981,9 @@ class TemplateProgrammer(object):
                 check_type(headers.get('X-Auth-Token'),
                            basestring, may_be_none=False)
 
+        # avoid name conflict
+        params_arg = params
+
         params = {
         }
         params.update(request_parameters)
@@ -991,7 +994,7 @@ class TemplateProgrammer(object):
 
         _payload = {
             'params':
-                params,
+                params_arg,
             'templateId':
                 templateId,
         }

--- a/dnacentersdk/api/v1_3_0/template_programmer.py
+++ b/dnacentersdk/api/v1_3_0/template_programmer.py
@@ -785,6 +785,9 @@ class TemplateProgrammer(object):
                 check_type(headers.get('X-Auth-Token'),
                            basestring, may_be_none=False)
 
+        # avoid name conflict
+        params_arg = params
+
         params = {
         }
         params.update(request_parameters)
@@ -795,7 +798,7 @@ class TemplateProgrammer(object):
 
         _payload = {
             'params':
-                params,
+                params_arg,
             'templateId':
                 templateId,
         }

--- a/dnacentersdk/api/v1_3_1/configuration_templates.py
+++ b/dnacentersdk/api/v1_3_1/configuration_templates.py
@@ -1172,6 +1172,9 @@ class ConfigurationTemplates(object):
                 check_type(headers.get('X-Auth-Token'),
                            basestring, may_be_none=False)
 
+        # avoid name conflict
+        params_arg = params
+
         params = {
         }
         params.update(request_parameters)
@@ -1182,7 +1185,7 @@ class ConfigurationTemplates(object):
 
         _payload = {
             'params':
-                params,
+                params_arg,
             'templateId':
                 templateId,
         }

--- a/dnacentersdk/api/v1_3_3/configuration_templates.py
+++ b/dnacentersdk/api/v1_3_3/configuration_templates.py
@@ -1094,6 +1094,9 @@ class ConfigurationTemplates(object):
                 check_type(headers.get('X-Auth-Token'),
                            basestring, may_be_none=False)
 
+        # avoid name conflict
+        params_arg = params
+
         params = {
         }
         params.update(request_parameters)
@@ -1104,7 +1107,7 @@ class ConfigurationTemplates(object):
 
         _payload = {
             'params':
-                params,
+                params_arg,
             'templateId':
                 templateId,
         }

--- a/dnacentersdk/api/v2_1_1/configuration_templates.py
+++ b/dnacentersdk/api/v2_1_1/configuration_templates.py
@@ -1094,6 +1094,9 @@ class ConfigurationTemplates(object):
                 check_type(headers.get('X-Auth-Token'),
                            basestring, may_be_none=False)
 
+        # avoid name conflict
+        params_arg = params
+
         params = {
         }
         params.update(request_parameters)
@@ -1104,7 +1107,7 @@ class ConfigurationTemplates(object):
 
         _payload = {
             'params':
-                params,
+                params_arg,
             'templateId':
                 templateId,
         }

--- a/dnacentersdk/api/v2_1_2/configuration_templates.py
+++ b/dnacentersdk/api/v2_1_2/configuration_templates.py
@@ -1094,6 +1094,9 @@ class ConfigurationTemplates(object):
                 check_type(headers.get('X-Auth-Token'),
                            basestring, may_be_none=False)
 
+        # avoid name conflict
+        params_arg = params
+
         params = {
         }
         params.update(request_parameters)
@@ -1104,7 +1107,7 @@ class ConfigurationTemplates(object):
 
         _payload = {
             'params':
-                params,
+                params_arg,
             'templateId':
                 templateId,
         }


### PR DESCRIPTION
the configuration_templates.update_template() call is not passing the right `params` value to DNAC, so the templates get rendered with an incorrect params list so values are not expanded.

This is due to a naming clash between the `params` function parameter and the `params` dict variable used throughout all the SDK methods.. I feel we should rename `params` to `_params` in all methods, but this is a ton of work, so I just avoided this clash in the few methods exposing `params`