### PR TITLE
### Fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.2] - 2022-07-29
+
+### Fixed
+- Removed enum in `sda`.`adds_border_device`:
+    + externalDomainRoutingProtocolName
+- Removed enum in `sda`.`add_multicast_in_sda_fabric`:
+    + multicastMethod
+- Removed enum in `site_design`.`provision_nfv`:
+    + linkType
+- Removed enum in `sda`.`add_transit_peer_network`:
+    + routingProtocolName
+- Removed enum in `network_settings`.`update_network` and `network_settings`.`create_network`:
+    + ipAddress
+    + sharedSecret
+    + domainName
+    + primaryIpAddress
+    + secondaryIpAddress
+    + network
+    + servers
+
 ## [2.5.1] - 2022-07-12
 
 ### Fixed
@@ -317,4 +337,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [2.4.11]: https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.4.10...v2.4.11
 [2.5.0]: https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.4.11...v2.5.0
 [2.5.1]: https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.5.0...v2.5.1
-[Unreleased]: https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.5.1...master
+[2.5.2]: https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.5.1...v2.5.2
+[Unreleased]: https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.5.2...master

--- a/dnacentersdk/models/validators/v2_2_1/jsd_cc72e307e5df50c48ce57370f27395a0.py
+++ b/dnacentersdk/models/validators/v2_2_1/jsd_cc72e307e5df50c48ce57370f27395a0.py
@@ -387,9 +387,7 @@ class JSONSchemaValidatorCc72E307E5Df50C48Ce57370F27395A0(object):
                 "type": "boolean"
                 },
                 "linkType": {
-                "enum": [
-                "GigabitEthernet"
-                ],
+                
                 "type": "string"
                 },
                 "serviceProvider": {

--- a/dnacentersdk/models/validators/v2_2_2_3/jsd_cc72e307e5df50c48ce57370f27395a0.py
+++ b/dnacentersdk/models/validators/v2_2_2_3/jsd_cc72e307e5df50c48ce57370f27395a0.py
@@ -387,9 +387,7 @@ class JSONSchemaValidatorCc72E307E5Df50C48Ce57370F27395A0(object):
                 "type": "boolean"
                 },
                 "linkType": {
-                "enum": [
-                "GigabitEthernet"
-                ],
+                
                 "type": "string"
                 },
                 "serviceProvider": {

--- a/dnacentersdk/models/validators/v2_3_3_0/jsd_b6f2d8e46cdd5f05bb06f52cd1b26fb2.py
+++ b/dnacentersdk/models/validators/v2_3_3_0/jsd_b6f2d8e46cdd5f05bb06f52cd1b26fb2.py
@@ -121,9 +121,7 @@ class JSONSchemaValidatorB6F2D8E46Cdd5F05Bb06F52Cd1B26Fb2(object):
                 "type": "array"
                 },
                 "externalDomainRoutingProtocolName": {
-                "enum": [
-                "BGP"
-                ],
+                
                 "type": "string"
                 },
                 "internalAutonomouSystemNumber": {

--- a/dnacentersdk/models/validators/v2_3_3_0/jsd_b7079a38844e56dd8f1b6b876880a02e.py
+++ b/dnacentersdk/models/validators/v2_3_3_0/jsd_b7079a38844e56dd8f1b6b876880a02e.py
@@ -41,9 +41,7 @@ class JSONSchemaValidatorB7079A38844E56Dd8F1B6B876880A02E(object):
                 "$schema": "http://json-schema.org/draft-04/schema#",
                 "properties": {
                 "multicastMethod": {
-                "enum": [
-                "native_multicast"
-                ],
+                
                 "type": "string"
                 },
                 "multicastType": {

--- a/dnacentersdk/models/validators/v2_3_3_0/jsd_cc72e307e5df50c48ce57370f27395a0.py
+++ b/dnacentersdk/models/validators/v2_3_3_0/jsd_cc72e307e5df50c48ce57370f27395a0.py
@@ -387,9 +387,7 @@ class JSONSchemaValidatorCc72E307E5Df50C48Ce57370F27395A0(object):
                 "type": "boolean"
                 },
                 "linkType": {
-                "enum": [
-                "GigabitEthernet"
-                ],
+                
                 "type": "string"
                 },
                 "serviceProvider": {

--- a/dnacentersdk/models/validators/v2_3_3_0/jsd_d7073129453698264e7519d82991c.py
+++ b/dnacentersdk/models/validators/v2_3_3_0/jsd_d7073129453698264e7519d82991c.py
@@ -46,9 +46,7 @@ class JSONSchemaValidatorD7073129453698264E7519D82991C(object):
                 "type": "string"
                 },
                 "routingProtocolName": {
-                "enum": [
-                "BGP"
-                ],
+                
                 "type": "string"
                 }
                 },

--- a/dnacentersdk/models/validators/v2_3_3_0/jsd_e1b8c435195d56368c24a54dcce007d0.py
+++ b/dnacentersdk/models/validators/v2_3_3_0/jsd_e1b8c435195d56368c24a54dcce007d0.py
@@ -45,9 +45,7 @@ class JSONSchemaValidatorE1B8C435195D56368C24A54Dcce007D0(object):
                 "clientAndEndpoint_aaa": {
                 "properties": {
                 "ipAddress": {
-                "enum": [
-                "Mandatory for ISE servers."
-                ],
+                
                 "type": "string"
                 },
                 "network": {
@@ -60,9 +58,7 @@ class JSONSchemaValidatorE1B8C435195D56368C24A54Dcce007D0(object):
                 "type": "string"
                 },
                 "sharedSecret": {
-                "enum": [
-                "Supported only by ISE servers"
-                ],
+                
                 "type": "string"
                 }
                 },
@@ -77,21 +73,15 @@ class JSONSchemaValidatorE1B8C435195D56368C24A54Dcce007D0(object):
                 "dnsServer": {
                 "properties": {
                 "domainName": {
-                "enum": [
-                "can only contain alphanumeric characters or hyphen"
-                ],
+                
                 "type": "string"
                 },
                 "primaryIpAddress": {
-                "enum": [
-                "valid range : 1.0.0.0 - 223.255.255.255"
-                ],
+                
                 "type": "string"
                 },
                 "secondaryIpAddress": {
-                "enum": [
-                "valid range : 1.0.0.0 - 223.255.255.255"
-                ],
+                
                 "type": "string"
                 }
                 },
@@ -122,30 +112,22 @@ class JSONSchemaValidatorE1B8C435195D56368C24A54Dcce007D0(object):
                 "network_aaa": {
                 "properties": {
                 "ipAddress": {
-                "enum": [
-                "Mandatory for ISE servers and for AAA consider this as additional Ip."
-                ],
+                
                 "type": "string"
                 },
                 "network": {
-                "enum": [
-                "For AAA server consider it as primary IP and For ISE consider as Network"
-                ],
+                
                 "type": "string"
                 },
                 "protocol": {
                 "type": "string"
                 },
                 "servers": {
-                "enum": [
-                "Server type supported by ISE and AAA"
-                ],
+                
                 "type": "string"
                 },
                 "sharedSecret": {
-                "enum": [
-                "Supported only by ISE servers"
-                ],
+                
                 "type": "string"
                 }
                 },

--- a/dnacentersdk/models/validators/v2_3_3_0/jsd_eca62ef076b5627a85b2a5959613fb8.py
+++ b/dnacentersdk/models/validators/v2_3_3_0/jsd_eca62ef076b5627a85b2a5959613fb8.py
@@ -45,9 +45,7 @@ class JSONSchemaValidatorEca62Ef076B5627A85B2A5959613Fb8(object):
                 "clientAndEndpoint_aaa": {
                 "properties": {
                 "ipAddress": {
-                "enum": [
-                "Mandatory for ISE servers."
-                ],
+                
                 "type": "string"
                 },
                 "network": {
@@ -60,9 +58,7 @@ class JSONSchemaValidatorEca62Ef076B5627A85B2A5959613Fb8(object):
                 "type": "string"
                 },
                 "sharedSecret": {
-                "enum": [
-                "Supported only by ISE servers"
-                ],
+                
                 "type": "string"
                 }
                 },
@@ -77,21 +73,15 @@ class JSONSchemaValidatorEca62Ef076B5627A85B2A5959613Fb8(object):
                 "dnsServer": {
                 "properties": {
                 "domainName": {
-                "enum": [
-                "can only contain alphanumeric characters or hyphen"
-                ],
+                
                 "type": "string"
                 },
                 "primaryIpAddress": {
-                "enum": [
-                "valid range : 1.0.0.0 - 223.255.255.255"
-                ],
+                
                 "type": "string"
                 },
                 "secondaryIpAddress": {
-                "enum": [
-                "valid range : 1.0.0.0 - 223.255.255.255"
-                ],
+                
                 "type": "string"
                 }
                 },
@@ -122,30 +112,22 @@ class JSONSchemaValidatorEca62Ef076B5627A85B2A5959613Fb8(object):
                 "network_aaa": {
                 "properties": {
                 "ipAddress": {
-                "enum": [
-                "Mandatory for ISE servers and for AAA consider this as additional Ip."
-                ],
+                
                 "type": "string"
                 },
                 "network": {
-                "enum": [
-                "For AAA server consider it as primary IP and For ISE consider as Network"
-                ],
+                
                 "type": "string"
                 },
                 "protocol": {
                 "type": "string"
                 },
                 "servers": {
-                "enum": [
-                "Server type supported by ISE and AAA"
-                ],
+                
                 "type": "string"
                 },
                 "sharedSecret": {
-                "enum": [
-                "Supported only by ISE servers"
-                ],
+                
                 "type": "string"
                 }
                 },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dnacentersdk"
-version = "2.5.1"
+version = "2.5.2"
 description = "Cisco DNA Center Platform SDK"
 authors = ["Jose Bogarin Solano <jbogarin@altus.cr>", "William Astorga <wastorga@altus.cr>"]
 license = "MIT"

--- a/tests/models/validators/v2_3_3_0/jsd_c27bbb42365955bc210924e1362c34.py
+++ b/tests/models/validators/v2_3_3_0/jsd_c27bbb42365955bc210924e1362c34.py
@@ -41,9 +41,7 @@ class JSONSchemaValidatorC27Bbb42365955Bc210924E1362C34(object):
                 "$schema": "http://json-schema.org/draft-04/schema#",
                 "properties": {
                 "multicastMethod": {
-                "enum": [
-                "native_multicast"
-                ],
+                
                 "type": "string"
                 },
                 "multicastType": {

--- a/tests/models/validators/v2_3_3_0/jsd_d1b2e541bb85dea8192cd474be4e3ad.py
+++ b/tests/models/validators/v2_3_3_0/jsd_d1b2e541bb85dea8192cd474be4e3ad.py
@@ -113,9 +113,7 @@ class JSONSchemaValidatorD1B2E541Bb85Dea8192Cd474Be4E3Ad(object):
                 "type": "string"
                 },
                 "type": {
-                "enum": [
-                "BUSINESS_RELEVANCE"
-                ],
+                
                 "type": "string"
                 }
                 },

--- a/tests/models/validators/v2_3_3_0/jsd_d39e10793a45d3db229d6d3820c665a.py
+++ b/tests/models/validators/v2_3_3_0/jsd_d39e10793a45d3db229d6d3820c665a.py
@@ -46,9 +46,7 @@ class JSONSchemaValidatorD39E10793A45D3DB229D6D3820C665A(object):
                 "type": "string"
                 },
                 "routingProtocolName": {
-                "enum": [
-                "BGP"
-                ],
+                
                 "type": "string"
                 }
                 },


### PR DESCRIPTION
- Removed enum in `sda`.`adds_border_device`:
    + externalDomainRoutingProtocolName
- Removed enum in `sda`.`add_multicast_in_sda_fabric`:
    + multicastMethod
- Removed enum in `site_design`.`provision_nfv`:
    + linkType
- Removed enum in `sda`.`add_transit_peer_network`:
    + routingProtocolName
- Removed enum in `network_settings`.`update_network` and `network_settings`.`create_network`:
    + ipAddress
    + sharedSecret
    + domainName
    + primaryIpAddress
    + secondaryIpAddress
    + network
    + servers