### PR TITLE
Max Rate Limit Retry

### DIFF
--- a/dnacentersdk/api/__init__.py
+++ b/dnacentersdk/api/__init__.py
@@ -30,6 +30,7 @@ from dnacentersdk.config import (
     DEFAULT_BASE_URL,
     DEFAULT_SINGLE_REQUEST_TIMEOUT,
     DEFAULT_WAIT_ON_RATE_LIMIT,
+    DEFAULT_MAX_RETRIES_ON_RATE_LIMIT,
     DEFAULT_VERIFY,
 )
 import dnacentersdk.environment as dnacenter_environment
@@ -654,6 +655,7 @@ class DNACenterAPI(object):
                  base_url=None,
                  single_request_timeout=None,
                  wait_on_rate_limit=None,
+                 max_retries_on_rate_limit=None,
                  verify=None,
                  version=None,
                  debug=None,
@@ -700,6 +702,11 @@ class DNACenterAPI(object):
                 environment variable or
                 dnacentersdk.config.DEFAULT_WAIT_ON_RATE_LIMIT
                 if the environment variable is not set.
+            max_retries_on_rate_limit(int): Maximum number of request retries
+                performed by automatic rate-limit handling Defaults to the
+                DNA_CENTER_MAX_RETRIES_ON_RATE_LIMIT environment variable or
+                dnacentersdk.config.DEFAULT_MAX_RETRIES_ON_RATE_LIMIT
+                if the environment variable is not set.
             verify(bool,basestring): Controls whether we verify the server's
                 TLS certificate, or a string, in which case it must be a path
                 to a CA bundle to use. Defaults to the DNA_CENTER_VERIFY 
@@ -745,8 +752,12 @@ class DNACenterAPI(object):
         if wait_on_rate_limit is None:
             wait_on_rate_limit = dnacenter_environment.get_env_wait_on_rate_limit() or DEFAULT_WAIT_ON_RATE_LIMIT
 
+        if max_retries_on_rate_limit is None:
+            max_retries_on_rate_limit = dnacenter_environment.get_env_max_retries_on_rate_limit() \
+                if dnacenter_environment.get_env_max_retries_on_rate_limit() is not None else DEFAULT_MAX_RETRIES_ON_RATE_LIMIT
+
         if verify is None:
-            verify = dnacenter_environment.get_env_verify() if dnacenter_environment.get_env_verify() != None else DEFAULT_VERIFY
+            verify = dnacenter_environment.get_env_verify() if dnacenter_environment.get_env_verify() is not None else DEFAULT_VERIFY
 
         version = version or dnacenter_environment.get_env_version() or DEFAULT_VERSION
 
@@ -813,6 +824,7 @@ class DNACenterAPI(object):
             base_url=base_url,
             single_request_timeout=single_request_timeout,
             wait_on_rate_limit=wait_on_rate_limit,
+            max_retries_on_rate_limit=max_retries_on_rate_limit,
             verify=verify,
             version=version,
             debug=debug,

--- a/dnacentersdk/config.py
+++ b/dnacentersdk/config.py
@@ -40,6 +40,10 @@ DEFAULT_SINGLE_REQUEST_TIMEOUT = 60
 #: Enables or disables automatic rate-limit handling.
 DEFAULT_WAIT_ON_RATE_LIMIT = True
 
+#: **retries_on_rate_limit** default value.
+#: Maximum number of times automatic rate-limit handling retries requests.
+DEFAULT_MAX_RETRIES_ON_RATE_LIMIT = 5
+
 #: **verify** default value.
 #: Controls whether to verify the server's TLS certificate or not.
 DEFAULT_VERIFY = True

--- a/dnacentersdk/environment.py
+++ b/dnacentersdk/environment.py
@@ -50,6 +50,9 @@ SINGLE_REQUEST_TIMEOUT_ENVIRONMENT_VARIABLE = \
 #: name of the environment wait_on_rate_limit variable
 WAIT_ON_RATE_LIMIT_ENVIRONMENT_VARIABLE = 'DNA_CENTER_WAIT_ON_RATE_LIMIT'
 
+#: name of the environment max_retries_on_rate_limit variable
+MAX_RETRIES_ON_RATE_LIMIT_ENVIRONMENT_VARIABLE = 'DNA_CENTER_MAX_RETRIES_ON_RATE_LIMIT'
+
 #: name of the environment verify variable
 VERIFY_ENVIRONMENT_VARIABLE = 'DNA_CENTER_VERIFY'
 
@@ -118,6 +121,13 @@ def get_env_wait_on_rate_limit():
         WAIT_ON_RATE_LIMIT_ENVIRONMENT_VARIABLE,
         bool, _is_bool)
     return DNA_CENTER_WAIT_ON_RATE_LIMIT
+
+
+def get_env_max_retries_on_rate_limit():
+    DNA_CENTER_MAX_RETRIES_ON_RATE_LIMIT = _get_env_value(
+        MAX_RETRIES_ON_RATE_LIMIT_ENVIRONMENT_VARIABLE,
+        int, int)
+    return DNA_CENTER_MAX_RETRIES_ON_RATE_LIMIT
 
 
 def get_env_verify():

--- a/dnacentersdk/restsession.py
+++ b/dnacentersdk/restsession.py
@@ -460,18 +460,6 @@ class RestSession(object):
                                                          **kwargs)
                 except Exception as e:
                     raise dnacentersdkException('Socket error {}'.format(e))
-            except IOError as e:
-                if e.errno == errno.EPIPE:
-                    # EPIPE error
-                    try:
-                        c += 1
-                        logger.debug('Attempt {}'.format(c))
-                        response = self._req_session.request(method, abs_url,
-                                                             **kwargs)
-                    except Exception as e:
-                        raise dnacentersdkException('PipeError {}'.format(e))
-                else:
-                    raise dnacentersdkException('IOError {}'.format(e))
             try:
                 # Check the response code for error conditions
                 check_response_code(response, erc)

--- a/dnacentersdk/restsession.py
+++ b/dnacentersdk/restsession.py
@@ -466,7 +466,7 @@ class RestSession(object):
             except RateLimitError as e:
                 # Catch rate-limit errors
                 # Wait and retry if automatic rate-limit handling is enabled
-                if self.wait_on_rate_limit and rate_limit_retry <= self._max_retries_on_rate_limit:
+                if self.wait_on_rate_limit and rate_limit_retry < self._max_retries_on_rate_limit:
                     logger.warning(RateLimitWarning(response))
                     rate_limit_retry += 1
                     time.sleep(e.retry_after)


### PR DESCRIPTION

The objective of the retry limit is done to ensure the lack of a infinite loop while trying to handle rate limit. Recent issues involving shared credentials spamming a dnac brought this about. This pr also removes an exception that was redundant as IOError is an alias for OSError as is socket.error.