### PR TITLE
changed authentication from on client creation to lazy authentication…

### DIFF
--- a/dnacentersdk/api/__init__.py
+++ b/dnacentersdk/api/__init__.py
@@ -490,7 +490,6 @@ class DNACenterAPI(object):
         # cloud.
         self._session = RestSession(
             get_access_token=get_access_token,
-            access_token=get_access_token(),
             base_url=base_url,
             single_request_timeout=single_request_timeout,
             wait_on_rate_limit=wait_on_rate_limit,


### PR DESCRIPTION
Pull Request Overview: Lazy Authentication Implementation
🚀 What Changed
Implemented lazy authentication for the DNA Center SDK, changing when authentication occurs from client initialization to the first API request.

📁 Files Modified
restsession.py - Core authentication logic changes
__init__.py - DNACenterAPI initialization changes
test_restsession.py - Added comprehensive test coverage
🔧 Key Changes
1. RestSession Class (restsession.py)

Removed access_token parameter from constructor
Added _authenticated flag to track authentication state
Added _ensure_authenticated() method for on-demand authentication
Modified access_token property to trigger lazy authentication
Updated request() method to authenticate before first API call
2. DNACenterAPI Class (__init__.py)

Removed immediate get_access_token() call during initialization
Authentication now deferred until first API request
3. Test Coverage (test_restsession.py)

Added test_lazy_authentication() to verify lazy authentication behavior
Tests confirm no authentication during initialization
Validates authentication triggers on first API request
Ensures subsequent requests don't re-authenticate
✅ Benefits
⚡ Faster Initialization: API clients create instantly without network calls
🔄 On-Demand Authentication: Only authenticates when actually needed
🔒 Backward Compatible: No breaking changes to public API
🛡️ Preserved Error Handling: Token refresh and 401 handling still work
📈 Better Performance: Eliminates unnecessary authentication for unused clients
🧪 Testing
All existing functionality preserved
New test validates lazy authentication behavior
Confirms authentication state management works correctly
This change improves SDK performance by eliminating upfront authentication overhead while maintaining full compatibility with existing code.