### PR TITLE
Fixed the validation issue for value parameter by updating the type to array

### DIFF
--- a/dnacentersdk/models/validators/v3_1_3_0/jsd_fa310ab095148bdb00d7d3d5e1676.py
+++ b/dnacentersdk/models/validators/v3_1_3_0/jsd_fa310ab095148bdb00d7d3d5e1676.py
@@ -106,7 +106,7 @@ class JSONSchemaValidatorFa310Ab095148Bdb00D7D3D5E1676(object):
                 "type": "string"
                 },
                 "value": {
-                "type": "object"
+                "type": "array"
                 }
                 },
                 "type": "object"


### PR DESCRIPTION
**Description:**
This PR fixes a schema validation error in the Cisco DNA Center SDK for create_or_schedule_a_report() where the field filters.value was incorrectly defined as an object instead of an array.

Due to this mismatch, valid payloads containing a list of filter values (as expected by the Catalyst Center API) failed validation with the error:
data.view.filters[0].value must be object


**Change Summary:**

Updated the schema definition in
dnacentersdk/models/validators/v3_1_3_0/jsd_fa310ab095148bdb00d7d3d5e1676.py
from:
    "value": {"type": "object"}
to:
    "value": {"type": "array"}
    
**Impact:**
Enables correct payload validation and successful execution of create_or_schedule_a_report() when using list-based filters.value.
Aligns SDK behavior with the Catalyst Center API, which accepts an array for filters.value.
