### PR TITLE
fix: resolve issues equivalent to catalystcentersdk #17, #20, #246 (v…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.3] - 2026-05-05
+### Fixed
+- **Download config methods missing stream support (Issue #246 equivalent / Issue #17)**: Fixed `download_masked_device_configuration()` and `download_unmaskedraw_device_configuration_as_zip()` in Configuration Archive module for v3.1.6.0. These methods were missing `stream=True`, `dirpath`, `save_file`, and `filename` parameters, causing binary file responses to be parsed as JSON and raising `JSONDecodeError`. The fix restores the correct `DownloadResponse`-based implementation present in v2.3.7.9 and v3.1.3.0.
+- **Webhook destination headers collision (Issue #20 equivalent)**: Fixed `TypeError` in `create_webhook_destination()` and `update_webhook_destination()` (including `_v1` variants) across all API versions (2.3.5.3, 2.3.7.6, 2.3.7.9, 3.1.3.0, 3.1.6.0) in the Event Management module. The `headers` parameter was incorrectly overloaded for both webhook custom headers (list) and HTTP request headers (dict). Renamed the webhook payload field parameter to `webhook_headers` to eliminate the collision. Users must now pass custom webhook headers via `webhook_headers=[...]`; the `headers` parameter continues to accept a dict for HTTP transport.
+- **Missing `udldGlobalConfig` support (Issue #246)**: Added `udldGlobalConfig` parameter to `create_configurations_for_an_intended_layer2_feature_on_a_wired_device()` and `update_configurations_for_an_intended_layer2_feature_on_a_wired_device()` across all API versions (2.3.7.9, 3.1.3.0, 3.1.6.0) in the Wired module. UDLD global configuration can now be created and updated through the SDK.
+- **Content-Type None TypeError (Issue #18 equivalent)**: Confirmed fix is already present in `dnacentersdk/utils.py` (`response.headers.get("Content-Type")` is guarded with a `None` check). No change needed.
+- **Port Channel Configuration validator key casing (portchannelConfig)**: Updated request validator schemas for v2.3.7.9, v3.1.3.0, and v3.1.6.0 (`jsd_d7b57050bdb98e9340d0bc4dba`, `jsd_ee7664344f50cb8f2c94beaa01629d`) to use `"portchannelConfig"` (lowercase c) matching the payload key already corrected in [2.10.6]. Previously the schema used `"portChannelConfig"` (uppercase C), so the validator was not actually validating the portchannel payload field.
+- **`udldGlobalConfig` validator relaxed**: Replaced the strict `udldGlobalConfig` JSON schema (which constrained `configType` to an enum, `isUdldEnabled`/`udldAggressive` to booleans, and `messageTime` to integer) with an open schema (`{}`) across all API versions (2.3.7.9, 3.1.3.0, 3.1.6.0). The field is not present in the official Cisco Catalyst Center OpenAPI specification, so a permissive schema prevents false validation failures as the API evolves.
+
 ## [2.11.2] - 2026-02-26
 ### Fixed
 - **`limit` and `offset` parameter types (v2.3.7.9, v3.1.3.0)**: Changed `limit` and `offset` query parameters from `str` to `int` type in `check_type` validations and docstrings across multiple modules, matching the corrected types already applied in v3.1.6.0. Affected modules:
@@ -861,4 +870,5 @@ respond with a binary.
 [2.11.0]: https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.10.6...v2.11.0
 [2.11.1]: https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.11.0...v2.11.1
 [2.11.2]: https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.11.1...v2.11.2
-[Unreleased]: https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.11.2...develop
+[2.11.3]: https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.11.2...v2.11.3
+[Unreleased]: https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.11.3...develop

--- a/dnacentersdk/api/v2_3_5_3/event_management.py
+++ b/dnacentersdk/api/v2_3_5_3/event_management.py
@@ -2614,12 +2614,12 @@ class EventManagement(object):
     def create_webhook_destination(
         self,
         description=None,
-        headers=None,
         method=None,
         name=None,
         trustCert=None,
         url=None,
         webhookId=None,
+        webhook_headers=None,
         http_headers=None,
         payload=None,
         active_validation=True,
@@ -2629,12 +2629,12 @@ class EventManagement(object):
 
         Args:
             description(string): Event Management's Description.
-            headers(list): Event Management's headers (list of objects).
             method(string): Event Management's Method. Available values are 'POST' and 'PUT'.
             name(string): Event Management's Name.
             trustCert(boolean): Event Management's Trust Cert.
             url(string): Event Management's Url.
             webhookId(string): Event Management's Required only for update webhook configuration .
+            webhook_headers(list): Event Management's headers (list of objects).
             http_headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             payload(dict): A JSON serializable Python object to send in the
@@ -2675,7 +2675,7 @@ class EventManagement(object):
             "url": url,
             "method": method,
             "trustCert": trustCert,
-            "headers": headers,
+            "headers": webhook_headers,
         }
         _payload.update(payload or {})
         _payload = dict_from_items_with_values(_payload)
@@ -2708,12 +2708,12 @@ class EventManagement(object):
     def update_webhook_destination(
         self,
         description=None,
-        headers=None,
         method=None,
         name=None,
         trustCert=None,
         url=None,
         webhookId=None,
+        webhook_headers=None,
         http_headers=None,
         payload=None,
         active_validation=True,
@@ -2723,12 +2723,12 @@ class EventManagement(object):
 
         Args:
             description(string): Event Management's Description.
-            headers(list): Event Management's headers (list of objects).
             method(string): Event Management's Method. Available values are 'POST' and 'PUT'.
             name(string): Event Management's Name.
             trustCert(boolean): Event Management's Trust Cert.
             url(string): Event Management's Url.
             webhookId(string): Event Management's Required only for update webhook configuration .
+            webhook_headers(list): Event Management's headers (list of objects).
             http_headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             payload(dict): A JSON serializable Python object to send in the
@@ -2767,7 +2767,7 @@ class EventManagement(object):
             "url": url,
             "method": method,
             "trustCert": trustCert,
-            "headers": headers,
+            "headers": webhook_headers,
         }
         _payload.update(payload or {})
         _payload = dict_from_items_with_values(_payload)

--- a/dnacentersdk/api/v2_3_7_6/event_management.py
+++ b/dnacentersdk/api/v2_3_7_6/event_management.py
@@ -2838,13 +2838,13 @@ class EventManagement(object):
     def create_webhook_destination_v1(
         self,
         description=None,
-        headers=None,
         isProxyRoute=None,
         method=None,
         name=None,
         trustCert=None,
         url=None,
         webhookId=None,
+        webhook_headers=None,
         payload=None,
         http_headers=None,
         active_validation=True,
@@ -2854,13 +2854,13 @@ class EventManagement(object):
 
         Args:
             description(string): Event Management's Description.
-            headers(list): Event Management's headers (list of objects).
             isProxyRoute(boolean): Event Management's Is Proxy Route.
             method(string): Event Management's Method. Available values are 'POST' and 'PUT'.
             name(string): Event Management's Name.
             trustCert(boolean): Event Management's Trust Cert.
             url(string): Event Management's Url.
             webhookId(string): Event Management's Required only for update webhook configuration .
+            webhook_headers(list): Event Management's headers (list of objects).
             http_headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             payload(dict): A JSON serializable Python object to send in the
@@ -2901,7 +2901,7 @@ class EventManagement(object):
             "url": url,
             "method": method,
             "trustCert": trustCert,
-            "headers": headers,
+            "headers": webhook_headers,
             "isProxyRoute": isProxyRoute,
         }
         _payload.update(payload or {})
@@ -2935,13 +2935,13 @@ class EventManagement(object):
     def update_webhook_destination_v1(
         self,
         description=None,
-        headers=None,
         isProxyRoute=None,
         method=None,
         name=None,
         trustCert=None,
         url=None,
         webhookId=None,
+        webhook_headers=None,
         payload=None,
         http_headers=None,
         active_validation=True,
@@ -2951,13 +2951,13 @@ class EventManagement(object):
 
         Args:
             description(string): Event Management's Description.
-            headers(list): Event Management's headers (list of objects).
             isProxyRoute(boolean): Event Management's Is Proxy Route.
             method(string): Event Management's Method. Available values are 'POST' and 'PUT'.
             name(string): Event Management's Name.
             trustCert(boolean): Event Management's Trust Cert.
             url(string): Event Management's Url.
             webhookId(string): Event Management's Required only for update webhook configuration .
+            webhook_headers(list): Event Management's headers (list of objects).
             http_headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             payload(dict): A JSON serializable Python object to send in the
@@ -2996,7 +2996,7 @@ class EventManagement(object):
             "url": url,
             "method": method,
             "trustCert": trustCert,
-            "headers": headers,
+            "headers": webhook_headers,
             "isProxyRoute": isProxyRoute,
         }
         _payload.update(payload or {})
@@ -3926,13 +3926,13 @@ class EventManagement(object):
     def create_webhook_destination(
         self,
         description=None,
-        headers=None,
         isProxyRoute=None,
         method=None,
         name=None,
         trustCert=None,
         url=None,
         webhookId=None,
+        webhook_headers=None,
         payload=None,
         http_headers=None,
         active_validation=True,
@@ -3941,13 +3941,13 @@ class EventManagement(object):
         """This function is an alias of create_webhook_destination_v1 .
         Args:
             description(string): Event Management's Description.
-            headers(list): Event Management's headers (list of objects).
             isProxyRoute(boolean): Event Management's Is Proxy Route.
             method(string): Event Management's Method. Available values are 'POST' and 'PUT'.
             name(string): Event Management's Name.
             trustCert(boolean): Event Management's Trust Cert.
             url(string): Event Management's Url.
             webhookId(string): Event Management's Required only for update webhook configuration .
+            webhook_headers(list): Event Management's headers (list of objects).
             http_headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             payload(): A JSON serializable Python object to send in the
@@ -3962,7 +3962,7 @@ class EventManagement(object):
         """
         return self.create_webhook_destination_v1(
             description=description,
-            headers=headers,
+            webhook_headers=webhook_headers,
             isProxyRoute=isProxyRoute,
             method=method,
             name=name,
@@ -4272,13 +4272,13 @@ class EventManagement(object):
     def update_webhook_destination(
         self,
         description=None,
-        headers=None,
         isProxyRoute=None,
         method=None,
         name=None,
         trustCert=None,
         url=None,
         webhookId=None,
+        webhook_headers=None,
         payload=None,
         http_headers=None,
         active_validation=True,
@@ -4287,13 +4287,13 @@ class EventManagement(object):
         """This function is an alias of update_webhook_destination_v1 .
         Args:
             description(string): Event Management's Description.
-            headers(list): Event Management's headers (list of objects).
             isProxyRoute(boolean): Event Management's Is Proxy Route.
             method(string): Event Management's Method. Available values are 'POST' and 'PUT'.
             name(string): Event Management's Name.
             trustCert(boolean): Event Management's Trust Cert.
             url(string): Event Management's Url.
             webhookId(string): Event Management's Required only for update webhook configuration .
+            webhook_headers(list): Event Management's headers (list of objects).
             http_headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             payload(): A JSON serializable Python object to send in the
@@ -4308,7 +4308,7 @@ class EventManagement(object):
         """
         return self.update_webhook_destination_v1(
             description=description,
-            headers=headers,
+            webhook_headers=webhook_headers,
             isProxyRoute=isProxyRoute,
             method=method,
             name=name,

--- a/dnacentersdk/api/v2_3_7_9/event_management.py
+++ b/dnacentersdk/api/v2_3_7_9/event_management.py
@@ -2835,13 +2835,13 @@ class EventManagement(object):
     def create_webhook_destination(
         self,
         description=None,
-        headers=None,
         isProxyRoute=None,
         method=None,
         name=None,
         trustCert=None,
         url=None,
         webhookId=None,
+        webhook_headers=None,
         http_headers=None,
         payload=None,
         active_validation=True,
@@ -2851,13 +2851,13 @@ class EventManagement(object):
 
         Args:
             description(string): Event Management's Description.
-            headers(list): Event Management's headers (list of objects).
             isProxyRoute(boolean): Event Management's Is Proxy Route.
             method(string): Event Management's Method. Available values are 'POST' and 'PUT'.
             name(string): Event Management's Name.
             trustCert(boolean): Event Management's Trust Cert.
             url(string): Event Management's Url.
             webhookId(string): Event Management's Required only for update webhook configuration .
+            webhook_headers(list): Event Management's headers (list of objects).
             http_headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             payload(dict): A JSON serializable Python object to send in the
@@ -2898,7 +2898,7 @@ class EventManagement(object):
             "url": url,
             "method": method,
             "trustCert": trustCert,
-            "headers": headers,
+            "headers": webhook_headers,
             "isProxyRoute": isProxyRoute,
         }
         _payload.update(payload or {})
@@ -2932,13 +2932,13 @@ class EventManagement(object):
     def update_webhook_destination(
         self,
         description=None,
-        headers=None,
         isProxyRoute=None,
         method=None,
         name=None,
         trustCert=None,
         url=None,
         webhookId=None,
+        webhook_headers=None,
         http_headers=None,
         payload=None,
         active_validation=True,
@@ -2948,13 +2948,13 @@ class EventManagement(object):
 
         Args:
             description(string): Event Management's Description.
-            headers(list): Event Management's headers (list of objects).
             isProxyRoute(boolean): Event Management's Is Proxy Route.
             method(string): Event Management's Method. Available values are 'POST' and 'PUT'.
             name(string): Event Management's Name.
             trustCert(boolean): Event Management's Trust Cert.
             url(string): Event Management's Url.
             webhookId(string): Event Management's Required only for update webhook configuration .
+            webhook_headers(list): Event Management's headers (list of objects).
             http_headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             payload(dict): A JSON serializable Python object to send in the
@@ -2993,7 +2993,7 @@ class EventManagement(object):
             "url": url,
             "method": method,
             "trustCert": trustCert,
-            "headers": headers,
+            "headers": webhook_headers,
             "isProxyRoute": isProxyRoute,
         }
         _payload.update(payload or {})

--- a/dnacentersdk/api/v2_3_7_9/wired.py
+++ b/dnacentersdk/api/v2_3_7_9/wired.py
@@ -627,6 +627,7 @@ class Wired(object):
         stpInterfaceConfig=None,
         switchportInterfaceConfig=None,
         trunkInterfaceConfig=None,
+        udldGlobalConfig=None,
         vlanConfig=None,
         vtpGlobalConfig=None,
         vtpInterfaceConfig=None,
@@ -660,6 +661,7 @@ class Wired(object):
             stpInterfaceConfig(object): Wired's stpInterfaceConfig.
             switchportInterfaceConfig(object): Wired's switchportInterfaceConfig.
             trunkInterfaceConfig(object): Wired's trunkInterfaceConfig.
+            udldGlobalConfig(object): Wired's udldGlobalConfig.
             vlanConfig(object): Wired's vlanConfig.
             vtpGlobalConfig(object): Wired's vtpGlobalConfig.
             vtpInterfaceConfig(object): Wired's vtpInterfaceConfig.
@@ -717,6 +719,7 @@ class Wired(object):
             "stpGlobalConfig": stpGlobalConfig,
             "stpInterfaceConfig": stpInterfaceConfig,
             "trunkInterfaceConfig": trunkInterfaceConfig,
+            "udldGlobalConfig": udldGlobalConfig,
             "vtpGlobalConfig": vtpGlobalConfig,
             "vtpInterfaceConfig": vtpInterfaceConfig,
             "vlanConfig": vlanConfig,
@@ -774,6 +777,7 @@ class Wired(object):
         stpInterfaceConfig=None,
         switchportInterfaceConfig=None,
         trunkInterfaceConfig=None,
+        udldGlobalConfig=None,
         vlanConfig=None,
         vtpGlobalConfig=None,
         vtpInterfaceConfig=None,
@@ -806,6 +810,7 @@ class Wired(object):
             stpInterfaceConfig(object): Wired's stpInterfaceConfig.
             switchportInterfaceConfig(object): Wired's switchportInterfaceConfig.
             trunkInterfaceConfig(object): Wired's trunkInterfaceConfig.
+            udldGlobalConfig(object): Wired's udldGlobalConfig.
             vlanConfig(object): Wired's vlanConfig.
             vtpGlobalConfig(object): Wired's vtpGlobalConfig.
             vtpInterfaceConfig(object): Wired's vtpInterfaceConfig.
@@ -864,6 +869,7 @@ class Wired(object):
             "stpGlobalConfig": stpGlobalConfig,
             "stpInterfaceConfig": stpInterfaceConfig,
             "trunkInterfaceConfig": trunkInterfaceConfig,
+            "udldGlobalConfig": udldGlobalConfig,
             "vtpGlobalConfig": vtpGlobalConfig,
             "vtpInterfaceConfig": vtpInterfaceConfig,
             "vlanConfig": vlanConfig,

--- a/dnacentersdk/api/v3_1_3_0/event_management.py
+++ b/dnacentersdk/api/v3_1_3_0/event_management.py
@@ -2835,13 +2835,13 @@ class EventManagement(object):
     def create_webhook_destination(
         self,
         description=None,
-        headers=None,
         isProxyRoute=None,
         method=None,
         name=None,
         trustCert=None,
         url=None,
         webhookId=None,
+        webhook_headers=None,
         http_headers=None,
         payload=None,
         active_validation=True,
@@ -2851,13 +2851,13 @@ class EventManagement(object):
 
         Args:
             description(string): Event Management's Description.
-            headers(list): Event Management's headers (list of objects).
             isProxyRoute(boolean): Event Management's Is Proxy Route.
             method(string): Event Management's Method. Available values are 'POST' and 'PUT'.
             name(string): Event Management's Name.
             trustCert(boolean): Event Management's Trust Cert.
             url(string): Event Management's Url.
             webhookId(string): Event Management's Required only for update webhook configuration .
+            webhook_headers(list): Event Management's headers (list of objects).
             http_headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             payload(dict): A JSON serializable Python object to send in the
@@ -2898,7 +2898,7 @@ class EventManagement(object):
             "url": url,
             "method": method,
             "trustCert": trustCert,
-            "headers": headers,
+            "headers": webhook_headers,
             "isProxyRoute": isProxyRoute,
         }
         _payload.update(payload or {})
@@ -2932,13 +2932,13 @@ class EventManagement(object):
     def update_webhook_destination(
         self,
         description=None,
-        headers=None,
         isProxyRoute=None,
         method=None,
         name=None,
         trustCert=None,
         url=None,
         webhookId=None,
+        webhook_headers=None,
         http_headers=None,
         payload=None,
         active_validation=True,
@@ -2948,13 +2948,13 @@ class EventManagement(object):
 
         Args:
             description(string): Event Management's Description.
-            headers(list): Event Management's headers (list of objects).
             isProxyRoute(boolean): Event Management's Is Proxy Route.
             method(string): Event Management's Method. Available values are 'POST' and 'PUT'.
             name(string): Event Management's Name.
             trustCert(boolean): Event Management's Trust Cert.
             url(string): Event Management's Url.
             webhookId(string): Event Management's Required only for update webhook configuration .
+            webhook_headers(list): Event Management's headers (list of objects).
             http_headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             payload(dict): A JSON serializable Python object to send in the
@@ -2993,7 +2993,7 @@ class EventManagement(object):
             "url": url,
             "method": method,
             "trustCert": trustCert,
-            "headers": headers,
+            "headers": webhook_headers,
             "isProxyRoute": isProxyRoute,
         }
         _payload.update(payload or {})

--- a/dnacentersdk/api/v3_1_3_0/wired.py
+++ b/dnacentersdk/api/v3_1_3_0/wired.py
@@ -627,6 +627,7 @@ class Wired(object):
         stpInterfaceConfig=None,
         switchportInterfaceConfig=None,
         trunkInterfaceConfig=None,
+        udldGlobalConfig=None,
         vlanConfig=None,
         vtpGlobalConfig=None,
         vtpInterfaceConfig=None,
@@ -660,6 +661,7 @@ class Wired(object):
             stpInterfaceConfig(object): Wired's stpInterfaceConfig.
             switchportInterfaceConfig(object): Wired's switchportInterfaceConfig.
             trunkInterfaceConfig(object): Wired's trunkInterfaceConfig.
+            udldGlobalConfig(object): Wired's udldGlobalConfig.
             vlanConfig(object): Wired's vlanConfig.
             vtpGlobalConfig(object): Wired's vtpGlobalConfig.
             vtpInterfaceConfig(object): Wired's vtpInterfaceConfig.
@@ -717,6 +719,7 @@ class Wired(object):
             "stpGlobalConfig": stpGlobalConfig,
             "stpInterfaceConfig": stpInterfaceConfig,
             "trunkInterfaceConfig": trunkInterfaceConfig,
+            "udldGlobalConfig": udldGlobalConfig,
             "vtpGlobalConfig": vtpGlobalConfig,
             "vtpInterfaceConfig": vtpInterfaceConfig,
             "vlanConfig": vlanConfig,
@@ -774,6 +777,7 @@ class Wired(object):
         stpInterfaceConfig=None,
         switchportInterfaceConfig=None,
         trunkInterfaceConfig=None,
+        udldGlobalConfig=None,
         vlanConfig=None,
         vtpGlobalConfig=None,
         vtpInterfaceConfig=None,
@@ -806,6 +810,7 @@ class Wired(object):
             stpInterfaceConfig(object): Wired's stpInterfaceConfig.
             switchportInterfaceConfig(object): Wired's switchportInterfaceConfig.
             trunkInterfaceConfig(object): Wired's trunkInterfaceConfig.
+            udldGlobalConfig(object): Wired's udldGlobalConfig.
             vlanConfig(object): Wired's vlanConfig.
             vtpGlobalConfig(object): Wired's vtpGlobalConfig.
             vtpInterfaceConfig(object): Wired's vtpInterfaceConfig.
@@ -864,6 +869,7 @@ class Wired(object):
             "stpGlobalConfig": stpGlobalConfig,
             "stpInterfaceConfig": stpInterfaceConfig,
             "trunkInterfaceConfig": trunkInterfaceConfig,
+            "udldGlobalConfig": udldGlobalConfig,
             "vtpGlobalConfig": vtpGlobalConfig,
             "vtpInterfaceConfig": vtpInterfaceConfig,
             "vlanConfig": vlanConfig,

--- a/dnacentersdk/api/v3_1_6_0/configuration_archive.py
+++ b/dnacentersdk/api/v3_1_6_0/configuration_archive.py
@@ -441,26 +441,33 @@ class ConfigurationArchive(object):
         )
 
     def download_masked_device_configuration(
-        self, id, headers=None, **request_parameters
+        self, id, dirpath=None, save_file=None, filename=None, headers=None, **request_parameters
     ):
         """Download the masked (sanitized) device configuration by providing the file `id`.
 
         Args:
             id(str): id path parameter. The value of `id` can be obtained from the response of API
                 `/dna/intent/api/v1/networkDeviceConfigFiles`.
+            dirpath(str): Directory absolute path. Defaults to
+                os.getcwd().
+            save_file(bool): Enable or disable automatic file creation of
+                raw response.
+            filename(str): The filename used to save the download
+                file.
             headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             **request_parameters: Additional request parameters (provides
                 support for parameters that may be added in the future).
 
         Returns:
-            MyDict: JSON response. Access the object's properties by using
-            the dot notation or the bracket notation.
+            DownloadResponse: The DownloadResponse wrapper. Wraps the urllib3.response.HTTPResponse. For more
+            information check the `urlib3 documentation <https://urllib3.readthedocs.io/en/latest/reference/urllib3.response.html>`_
 
         Raises:
             TypeError: If the parameter types are incorrect.
             MalformedRequest: If the request body created is invalid.
             ApiError: If the Catalyst Center cloud returns an error.
+            DownloadFailure: If was not able to download the raw response to a file.
         Documentation Link:
             https://developer.cisco.com/docs/dna-center/#!download-masked-device-configuration
         """
@@ -490,10 +497,14 @@ class ConfigurationArchive(object):
         endpoint_full_url = apply_path_params(e_url, path_params)
         if with_custom_headers:
             json_data = self._session.post(
-                endpoint_full_url, params=_params, headers=_headers
+                endpoint_full_url, params=_params, headers=_headers,
+                stream=True, dirpath=dirpath, save_file=save_file, filename=filename
             )
         else:
-            json_data = self._session.post(endpoint_full_url, params=_params)
+            json_data = self._session.post(
+                endpoint_full_url, params=_params,
+                stream=True, dirpath=dirpath, save_file=save_file, filename=filename
+            )
 
         return self._object_factory(
             "bpm_fe0e28b3465084b5ee60a43602be1c_v3_1_6_0", json_data
@@ -503,6 +514,9 @@ class ConfigurationArchive(object):
         self,
         id,
         password=None,
+        dirpath=None,
+        save_file=None,
+        filename=None,
         headers=None,
         payload=None,
         active_validation=True,
@@ -520,6 +534,12 @@ class ConfigurationArchive(object):
                 space or the characters <>.
             id(str): id path parameter. The value of `id` can be obtained from the response of API
                 `/dna/intent/api/v1/networkDeviceConfigFiles`.
+            dirpath(str): Directory absolute path. Defaults to
+                os.getcwd().
+            save_file(bool): Enable or disable automatic file creation of
+                raw response.
+            filename(str): The filename used to save the download
+                file.
             headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             payload(dict): A JSON serializable Python object to send in the
@@ -530,13 +550,14 @@ class ConfigurationArchive(object):
                 support for parameters that may be added in the future).
 
         Returns:
-            MyDict: JSON response. Access the object's properties by using
-            the dot notation or the bracket notation.
+            DownloadResponse: The DownloadResponse wrapper. Wraps the urllib3.response.HTTPResponse. For more
+            information check the `urlib3 documentation <https://urllib3.readthedocs.io/en/latest/reference/urllib3.response.html>`_
 
         Raises:
             TypeError: If the parameter types are incorrect.
             MalformedRequest: If the request body created is invalid.
             ApiError: If the Catalyst Center cloud returns an error.
+            DownloadFailure: If was not able to download the raw response to a file.
         Documentation Link:
             https://developer.cisco.com/docs/dna-center/#!download-unmaskedraw-device-configuration-as-z-i-p
         """
@@ -576,11 +597,13 @@ class ConfigurationArchive(object):
         endpoint_full_url = apply_path_params(e_url, path_params)
         if with_custom_headers:
             json_data = self._session.post(
-                endpoint_full_url, params=_params, json=_payload, headers=_headers
+                endpoint_full_url, params=_params, json=_payload, headers=_headers,
+                stream=True, dirpath=dirpath, save_file=save_file, filename=filename
             )
         else:
             json_data = self._session.post(
-                endpoint_full_url, params=_params, json=_payload
+                endpoint_full_url, params=_params, json=_payload,
+                stream=True, dirpath=dirpath, save_file=save_file, filename=filename
             )
 
         return self._object_factory(

--- a/dnacentersdk/api/v3_1_6_0/event_management.py
+++ b/dnacentersdk/api/v3_1_6_0/event_management.py
@@ -2925,13 +2925,14 @@ class EventManagement(object):
     def create_webhook_destination(
         self,
         description=None,
-        headers=None,
         isProxyRoute=None,
         method=None,
         name=None,
         trustCert=None,
         url=None,
         webhookId=None,
+        webhook_headers=None,
+        headers=None,
         payload=None,
         active_validation=True,
         **request_parameters
@@ -2940,13 +2941,13 @@ class EventManagement(object):
 
         Args:
             description(string): Event Management's Description.
-            headers(list): Event Management's headers (list of objects).
             isProxyRoute(boolean): Event Management's Is Proxy Route.
             method(string): Event Management's Method. Available values are 'POST' and 'PUT'.
             name(string): Event Management's Name.
             trustCert(boolean): Event Management's Trust Cert.
             url(string): Event Management's Url.
             webhookId(string): Event Management's Required only for update webhook configuration.
+            webhook_headers(list): Event Management's headers (list of objects).
             headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             payload(dict): A JSON serializable Python object to send in the
@@ -2987,7 +2988,7 @@ class EventManagement(object):
             "url": url,
             "method": method,
             "trustCert": trustCert,
-            "headers": headers,
+            "headers": webhook_headers,
             "isProxyRoute": isProxyRoute,
         }
         _payload.update(payload or {})
@@ -3021,13 +3022,14 @@ class EventManagement(object):
     def update_webhook_destination(
         self,
         description=None,
-        headers=None,
         isProxyRoute=None,
         method=None,
         name=None,
         trustCert=None,
         url=None,
         webhookId=None,
+        webhook_headers=None,
+        headers=None,
         payload=None,
         active_validation=True,
         **request_parameters
@@ -3036,13 +3038,13 @@ class EventManagement(object):
 
         Args:
             description(string): Event Management's Description.
-            headers(list): Event Management's headers (list of objects).
             isProxyRoute(boolean): Event Management's Is Proxy Route.
             method(string): Event Management's Method. Available values are 'POST' and 'PUT'.
             name(string): Event Management's Name.
             trustCert(boolean): Event Management's Trust Cert.
             url(string): Event Management's Url.
             webhookId(string): Event Management's Required only for update webhook configuration.
+            webhook_headers(list): Event Management's headers (list of objects).
             headers(dict): Dictionary of HTTP Headers to send with the Request
                 .
             payload(dict): A JSON serializable Python object to send in the
@@ -3083,7 +3085,7 @@ class EventManagement(object):
             "url": url,
             "method": method,
             "trustCert": trustCert,
-            "headers": headers,
+            "headers": webhook_headers,
             "isProxyRoute": isProxyRoute,
         }
         _payload.update(payload or {})

--- a/dnacentersdk/api/v3_1_6_0/wired.py
+++ b/dnacentersdk/api/v3_1_6_0/wired.py
@@ -629,6 +629,7 @@ class Wired(object):
         stpInterfaceConfig=None,
         switchportInterfaceConfig=None,
         trunkInterfaceConfig=None,
+        udldGlobalConfig=None,
         vlanConfig=None,
         vtpGlobalConfig=None,
         vtpInterfaceConfig=None,
@@ -661,6 +662,7 @@ class Wired(object):
             stpInterfaceConfig(object): Wired's stpInterfaceConfig.
             switchportInterfaceConfig(object): Wired's switchportInterfaceConfig.
             trunkInterfaceConfig(object): Wired's trunkInterfaceConfig.
+            udldGlobalConfig(object): Wired's udldGlobalConfig.
             vlanConfig(object): Wired's vlanConfig.
             vtpGlobalConfig(object): Wired's vtpGlobalConfig.
             vtpInterfaceConfig(object): Wired's vtpInterfaceConfig.
@@ -721,6 +723,7 @@ class Wired(object):
             "stpGlobalConfig": stpGlobalConfig,
             "stpInterfaceConfig": stpInterfaceConfig,
             "trunkInterfaceConfig": trunkInterfaceConfig,
+            "udldGlobalConfig": udldGlobalConfig,
             "vtpGlobalConfig": vtpGlobalConfig,
             "vtpInterfaceConfig": vtpInterfaceConfig,
             "vlanConfig": vlanConfig,
@@ -778,6 +781,7 @@ class Wired(object):
         stpInterfaceConfig=None,
         switchportInterfaceConfig=None,
         trunkInterfaceConfig=None,
+        udldGlobalConfig=None,
         vlanConfig=None,
         vtpGlobalConfig=None,
         vtpInterfaceConfig=None,
@@ -811,6 +815,7 @@ class Wired(object):
             stpInterfaceConfig(object): Wired's stpInterfaceConfig.
             switchportInterfaceConfig(object): Wired's switchportInterfaceConfig.
             trunkInterfaceConfig(object): Wired's trunkInterfaceConfig.
+            udldGlobalConfig(object): Wired's udldGlobalConfig.
             vlanConfig(object): Wired's vlanConfig.
             vtpGlobalConfig(object): Wired's vtpGlobalConfig.
             vtpInterfaceConfig(object): Wired's vtpInterfaceConfig.
@@ -870,6 +875,7 @@ class Wired(object):
             "stpGlobalConfig": stpGlobalConfig,
             "stpInterfaceConfig": stpInterfaceConfig,
             "trunkInterfaceConfig": trunkInterfaceConfig,
+            "udldGlobalConfig": udldGlobalConfig,
             "vtpGlobalConfig": vtpGlobalConfig,
             "vtpInterfaceConfig": vtpInterfaceConfig,
             "vlanConfig": vlanConfig,

--- a/dnacentersdk/models/validators/v2_3_7_9/jsd_d7b57050bdb98e9340d0bc4dba.py
+++ b/dnacentersdk/models/validators/v2_3_7_9/jsd_d7b57050bdb98e9340d0bc4dba.py
@@ -609,7 +609,7 @@ class JSONSchemaValidatorD7B57050BdB98E9340D0Bc4Dba(object):
                 },
                 "type": "object"
                 },
-                "portChannelConfig": {
+                "portchannelConfig": {
                 "properties": {
                 "items": {
                 "items": {
@@ -1197,6 +1197,7 @@ class JSONSchemaValidatorD7B57050BdB98E9340D0Bc4Dba(object):
                 },
                 "type": "object"
                 },
+                "udldGlobalConfig": {},
                 "vlanConfig": {
                 "properties": {
                 "items": {

--- a/dnacentersdk/models/validators/v2_3_7_9/jsd_ee7664344f50cb8f2c94beaa01629d.py
+++ b/dnacentersdk/models/validators/v2_3_7_9/jsd_ee7664344f50cb8f2c94beaa01629d.py
@@ -609,7 +609,7 @@ class JSONSchemaValidatorEe7664344F50Cb8F2C94Beaa01629D(object):
                 },
                 "type": "object"
                 },
-                "portChannelConfig": {
+                "portchannelConfig": {
                 "properties": {
                 "items": {
                 "items": {
@@ -1197,6 +1197,7 @@ class JSONSchemaValidatorEe7664344F50Cb8F2C94Beaa01629D(object):
                 },
                 "type": "object"
                 },
+                "udldGlobalConfig": {},
                 "vlanConfig": {
                 "properties": {
                 "items": {

--- a/dnacentersdk/models/validators/v3_1_3_0/jsd_d7b57050bdb98e9340d0bc4dba.py
+++ b/dnacentersdk/models/validators/v3_1_3_0/jsd_d7b57050bdb98e9340d0bc4dba.py
@@ -609,7 +609,7 @@ class JSONSchemaValidatorD7B57050BdB98E9340D0Bc4Dba(object):
                 },
                 "type": "object"
                 },
-                "portChannelConfig": {
+                "portchannelConfig": {
                 "properties": {
                 "items": {
                 "items": {
@@ -1197,6 +1197,7 @@ class JSONSchemaValidatorD7B57050BdB98E9340D0Bc4Dba(object):
                 },
                 "type": "object"
                 },
+                "udldGlobalConfig": {},
                 "vlanConfig": {
                 "properties": {
                 "items": {

--- a/dnacentersdk/models/validators/v3_1_3_0/jsd_ee7664344f50cb8f2c94beaa01629d.py
+++ b/dnacentersdk/models/validators/v3_1_3_0/jsd_ee7664344f50cb8f2c94beaa01629d.py
@@ -609,7 +609,7 @@ class JSONSchemaValidatorEe7664344F50Cb8F2C94Beaa01629D(object):
                 },
                 "type": "object"
                 },
-                "portChannelConfig": {
+                "portchannelConfig": {
                 "properties": {
                 "items": {
                 "items": {
@@ -1197,6 +1197,7 @@ class JSONSchemaValidatorEe7664344F50Cb8F2C94Beaa01629D(object):
                 },
                 "type": "object"
                 },
+                "udldGlobalConfig": {},
                 "vlanConfig": {
                 "properties": {
                 "items": {

--- a/dnacentersdk/models/validators/v3_1_6_0/jsd_d7b57050bdb98e9340d0bc4dba.py
+++ b/dnacentersdk/models/validators/v3_1_6_0/jsd_d7b57050bdb98e9340d0bc4dba.py
@@ -574,7 +574,7 @@ class JSONSchemaValidatorD7B57050BdB98E9340D0Bc4Dba(object):
             },
             "type": "object"
         },
-        "portChannelConfig": {
+        "portchannelConfig": {
             "properties": {
                 "items": {
                     "items": {
@@ -1146,6 +1146,7 @@ class JSONSchemaValidatorD7B57050BdB98E9340D0Bc4Dba(object):
             },
             "type": "object"
         },
+        "udldGlobalConfig": {},
         "vlanConfig": {
             "properties": {
                 "items": {

--- a/dnacentersdk/models/validators/v3_1_6_0/jsd_ee7664344f50cb8f2c94beaa01629d.py
+++ b/dnacentersdk/models/validators/v3_1_6_0/jsd_ee7664344f50cb8f2c94beaa01629d.py
@@ -574,7 +574,7 @@ class JSONSchemaValidatorEe7664344F50Cb8F2C94Beaa01629D(object):
             },
             "type": "object"
         },
-        "portChannelConfig": {
+        "portchannelConfig": {
             "properties": {
                 "items": {
                     "items": {
@@ -1146,6 +1146,7 @@ class JSONSchemaValidatorEe7664344F50Cb8F2C94Beaa01629D(object):
             },
             "type": "object"
         },
+        "udldGlobalConfig": {},
         "vlanConfig": {
             "properties": {
                 "items": {

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -8,11 +8,71 @@ Changelog <https://keepachangelog.com/en/1.0.0/>`__, and this project
 adheres to `Semantic
 Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
-`Unreleased <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.11.2...develop>`__
+`Unreleased <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.11.3...develop>`__
 ---------------------------------------------------------------------------------------------------
+
+[2.11.3] - 2026-05-05
+---------------------
+
+Fixed
+~~~~~
+
+- **Download config methods missing stream support (Issue #246
+  equivalent / Issue #17)**: Fixed
+  ``download_masked_device_configuration()`` and
+  ``download_unmaskedraw_device_configuration_as_zip()`` in
+  Configuration Archive module for v3.1.6.0. These methods were missing
+  ``stream=True``, ``dirpath``, ``save_file``, and ``filename``
+  parameters, causing binary file responses to be parsed as JSON and
+  raising ``JSONDecodeError``. The fix restores the correct
+  ``DownloadResponse``-based implementation present in v2.3.7.9 and
+  v3.1.3.0.
+- **Webhook destination headers collision (Issue #20 equivalent)**:
+  Fixed ``TypeError`` in ``create_webhook_destination()`` and
+  ``update_webhook_destination()`` (including ``_v1`` variants) across
+  all API versions (2.3.5.3, 2.3.7.6, 2.3.7.9, 3.1.3.0, 3.1.6.0) in the
+  Event Management module. The ``headers`` parameter was incorrectly
+  overloaded for both webhook custom headers (list) and HTTP request
+  headers (dict). Renamed the webhook payload field parameter to
+  ``webhook_headers`` to eliminate the collision. Users must now pass
+  custom webhook headers via ``webhook_headers=[...]``; the ``headers``
+  parameter continues to accept a dict for HTTP transport.
+- **Missing ``udldGlobalConfig`` support (Issue #246)**: Added
+  ``udldGlobalConfig`` parameter to
+  ``create_configurations_for_an_intended_layer2_feature_on_a_wired_device()``
+  and
+  ``update_configurations_for_an_intended_layer2_feature_on_a_wired_device()``
+  across all API versions (2.3.7.9, 3.1.3.0, 3.1.6.0) in the Wired
+  module. UDLD global configuration can now be created and updated
+  through the SDK.
+- **Content-Type None TypeError (Issue #18 equivalent)**: Confirmed fix
+  is already present in ``dnacentersdk/utils.py``
+  (``response.headers.get("Content-Type")`` is guarded with a ``None``
+  check). No change needed.
+- **Port Channel Configuration validator key casing
+  (portchannelConfig)**: Updated request validator schemas for v2.3.7.9,
+  v3.1.3.0, and v3.1.6.0 (``jsd_d7b57050bdb98e9340d0bc4dba``,
+  ``jsd_ee7664344f50cb8f2c94beaa01629d``) to use ``"portchannelConfig"``
+  (lowercase c) matching the payload key already corrected in
+  `2.10.6 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.10.5...v2.10.6>`__.
+  Previously the schema used ``"portChannelConfig"`` (uppercase C), so
+  the validator was not actually validating the portchannel payload
+  field.
+- **``udldGlobalConfig`` validator relaxed**: Replaced the strict
+  ``udldGlobalConfig`` JSON schema (which constrained ``configType`` to
+  an enum, ``isUdldEnabled``/``udldAggressive`` to booleans, and
+  ``messageTime`` to integer) with an open schema (``{}``) across all
+  API versions (2.3.7.9, 3.1.3.0, 3.1.6.0). The field is not present in
+  the official Cisco Catalyst Center OpenAPI specification, so a
+  permissive schema prevents false validation failures as the API
+  evolves.
+
+.. _section-1:
 
 `2.11.2 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.11.1...v2.11.2>`__ - 2026-02-26
 ------------------------------------------------------------------------------------------------------------
+
+.. _fixed-1:
 
 Fixed
 ~~~~~
@@ -35,12 +95,12 @@ Fixed
   ``GetDeviceInterfaceStatsInfoV2`` and ``RogueAdditionalDetails``
   request validators.
 
-.. _section-1:
+.. _section-2:
 
 `2.11.1 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.11.0...v2.11.1>`__ - 2026-02-25
 ------------------------------------------------------------------------------------------------------------
 
-.. _fixed-1:
+.. _fixed-2:
 
 Fixed
 ~~~~~
@@ -62,7 +122,7 @@ Changed
   the previous ``.replace("\\n" + " " * 16, "")`` workaround. No
   functional change.
 
-.. _section-2:
+.. _section-3:
 
 `2.11.0 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.10.6...v2.11.0>`__ - 2026-02-04
 ------------------------------------------------------------------------------------------------------------
@@ -83,12 +143,12 @@ Changed
 
 - SDK is now compatible with Cisco Catalyst Center 3.1.6.0’s API.
 
-.. _section-3:
+.. _section-4:
 
 `2.10.6 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.10.5...v2.10.6>`__ - 2025-12-15
 ------------------------------------------------------------------------------------------------------------
 
-.. _fixed-2:
+.. _fixed-3:
 
 Fixed
 ~~~~~
@@ -125,12 +185,12 @@ Changed
   v2.3.7.9” in the User API Doc to properly separate v2.3.7.9 classes
   from v2.3.7.6, improving documentation clarity and navigation.
 
-.. _section-4:
+.. _section-5:
 
 `2.10.5 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.10.4...v2.10.5>`__ - 2025-10-29
 ------------------------------------------------------------------------------------------------------------
 
-.. _fixed-3:
+.. _fixed-4:
 
 Fixed
 ~~~~~
@@ -139,7 +199,7 @@ Fixed
   ``object`` to ``array`` in ``CreateOrScheduleAReport`` validator
   (``jsd_fa310ab095148bdb00d7d3d5e1676.py``).
 
-.. _section-5:
+.. _section-6:
 
 `2.10.4 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.10.3...v2.10.4>`__ - 2025-07-30
 ------------------------------------------------------------------------------------------------------------
@@ -260,7 +320,7 @@ Added
       →
       ``get_trend_analytics_data_for_thousand_eyes_test_results_in_the_specified_time_range``
 
-.. _fixed-4:
+.. _fixed-5:
 
 Fixed
 ~~~~~
@@ -341,12 +401,12 @@ Changed
 - **Documentation Consistency**: Function names now properly align with
   their respective API documentation and operation IDs.
 
-.. _section-6:
+.. _section-7:
 
 `2.10.3 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.10.2...v2.10.3>`__ - 2025-07-29
 ------------------------------------------------------------------------------------------------------------
 
-.. _fixed-5:
+.. _fixed-6:
 
 Fixed
 ~~~~~
@@ -410,12 +470,12 @@ Changed
   - Maintained backward compatibility where applicable through alias
     functions
 
-.. _section-7:
+.. _section-8:
 
 `2.10.2 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.10.1...v2.10.2>`__ - 2025-07-22
 ------------------------------------------------------------------------------------------------------------
 
-.. _fixed-6:
+.. _fixed-7:
 
 Fixed
 ~~~~~
@@ -448,12 +508,12 @@ Documentation
   explicit close methods, and migration guidance for updating existing
   code to use new resource management patterns.
 
-.. _section-8:
+.. _section-9:
 
 `2.10.1 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.10.0...v2.10.1>`__ - 2025-07-04
 ------------------------------------------------------------------------------------------------------------
 
-.. _fixed-7:
+.. _fixed-8:
 
 Fixed
 ~~~~~
@@ -467,7 +527,7 @@ Fixed
   ``download_unmaskedraw_device_configuration_as_z_ip`` to
   ``download_unmaskedraw_device_configuration_as_zip``.
 
-.. _section-9:
+.. _section-10:
 
 `2.10.0 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.9.1...v2.10.0>`__ - 2025-06-09
 -----------------------------------------------------------------------------------------------------------
@@ -494,7 +554,7 @@ Added
 - The v1 alias functions were all removed. Example… if your using
   “application_v1” you must be able to change it to “application”.
 
-.. _section-10:
+.. _section-11:
 
 `2.9.1 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.9.0...v2.9.1>`__ - 2025-05-09
 ---------------------------------------------------------------------------------------------------------
@@ -504,7 +564,7 @@ Fix
 
 - Modification of the get_reserve_ip_subpool_v1 function.
 
-.. _section-11:
+.. _section-12:
 
 `2.9.0 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.8.14...v2.9.0>`__ - 2025-05-09
 ----------------------------------------------------------------------------------------------------------
@@ -518,7 +578,7 @@ Added
 - Adds modules for v3_1_3_0
 - Modules 2_2_2_3, 2_2_3_3, 2_3_3_0 were removed
 
-.. _section-12:
+.. _section-13:
 
 `2.8.14 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.8.13...v2.8.14>`__ - 2025-05-05
 ------------------------------------------------------------------------------------------------------------
@@ -532,7 +592,7 @@ Fix
   download_unmaskedraw_device_configuration_as_z_ip_v1 function to
   correctly respond with a binary.
 
-.. _section-13:
+.. _section-14:
 
 `2.8.13 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.8.12...v2.8.13>`__ - 2025-04-25
 ------------------------------------------------------------------------------------------------------------
@@ -562,7 +622,7 @@ Fix
   get_the_interface_data_for_the_given_interface_idinstance_uuid_along_with_the_statistics_data_v1
   )
 
-.. _section-14:
+.. _section-15:
 
 `2.8.12 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.8.11...v2.8.12>`__ - 2025-04-08
 ------------------------------------------------------------------------------------------------------------
@@ -575,7 +635,7 @@ Fix
 - Fix in ignore_the_given_list_of_issues_v1 function in versions 2.3.7.6
   and 2.3.7.9.
 
-.. _section-15:
+.. _section-16:
 
 `2.8.11 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.8.10...v2.8.11>`__ - 2025-04-03
 ------------------------------------------------------------------------------------------------------------
@@ -589,7 +649,7 @@ Fix
 - sync_devices functionality has been added to devices.
 - Adjusted function names to avoid looping.
 
-.. _section-16:
+.. _section-17:
 
 `2.8.10 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.8.9...v2.8.10>`__ - 2025-04-01
 -----------------------------------------------------------------------------------------------------------
@@ -603,7 +663,7 @@ Fix
   downloads_a_specific_i_cap_packet_capture_file_v1 function to
   correctly respond with a binary.
 
-.. _section-17:
+.. _section-18:
 
 `2.8.9 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.8.8...v2.8.9>`__ - 2025-03-13
 ---------------------------------------------------------------------------------------------------------
@@ -618,7 +678,7 @@ Fix
   set_time_zone_for_a_site, set_d_n_s_settings_for_a_site,
   set_telemetry_settings_for_a_site, set_aaa_settings_for_a_site. #174
 
-.. _section-18:
+.. _section-19:
 
 `2.8.8 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.8.7...v2.8.8>`__ - 2025-03-10
 ---------------------------------------------------------------------------------------------------------
@@ -631,7 +691,7 @@ Fix
 - Modification of the data type in offset and limit. In the
   get_ap_profiles function of the wireless family.
 
-.. _section-19:
+.. _section-20:
 
 `2.8.7 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.8.6...v2.8.7>`__ - 2025-03-05
 ---------------------------------------------------------------------------------------------------------
@@ -643,7 +703,7 @@ Fix
 
 - Error correction in the user_and_roles module
 
-.. _section-20:
+.. _section-21:
 
 `2.8.6 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.8.5...v2.8.6>`__ - 2025-02-27
 ---------------------------------------------------------------------------------------------------------
@@ -655,7 +715,7 @@ Added
 
 - Add support of DNA Center versions (‘2.3.7.7’)
 
-.. _section-21:
+.. _section-22:
 
 `2.8.5 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.8.4...v2.8.5>`__ - 2025-02-21
 ---------------------------------------------------------------------------------------------------------
@@ -669,7 +729,7 @@ Fix
   deploy_template functions in version 1 and 2. In 2.3.5.3, 2.3.7.6 and
   2.3.7.9.
 
-.. _section-22:
+.. _section-23:
 
 `2.8.4 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.8.3...v2.8.4>`__ - 2025-02-17
 ---------------------------------------------------------------------------------------------------------
@@ -682,7 +742,7 @@ Fix
 - fix in create_webhook_destination, update_webhook_destination,
   get_webhook_destination functions. In versions 2.3.7.6 and 2.3.7.9.
 
-.. _section-23:
+.. _section-24:
 
 `2.8.3 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.8.2...v2.8.3>`__ - 2025-01-23
 ---------------------------------------------------------------------------------------------------------
@@ -704,7 +764,7 @@ Added
 
 - Cisco_IMC module added
 
-.. _section-24:
+.. _section-25:
 
 `2.8.2 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.8.1...v2.8.2>`__ - 2025-01-15
 ---------------------------------------------------------------------------------------------------------
@@ -721,7 +781,7 @@ Fix
   and 2.3.7.9.
 - issues #186
 
-.. _section-25:
+.. _section-26:
 
 `2.8.1 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.8.0...v2.8.1>`__ - 2025-01-13
 ---------------------------------------------------------------------------------------------------------
@@ -737,7 +797,7 @@ Fix
 - Fixed a bug in site_design in the uploads_floor_image function in
   versions 2.3.7.6 and 2.3.7.9.
 
-.. _section-26:
+.. _section-27:
 
 `2.8.0 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.7.7...v2.8.0>`__ - 2024-12-11
 ---------------------------------------------------------------------------------------------------------
@@ -750,7 +810,7 @@ Added
 - Add support of DNA Center versions (‘2.3.7.9’)
 - Adds modules for v2_3_7_9
 
-.. _section-27:
+.. _section-28:
 
 `2.7.7 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.7.6...v2.7.7>`__ - 2024-11-19
 ---------------------------------------------------------------------------------------------------------
@@ -761,7 +821,7 @@ Bug fix
 - The get_templates_details function was added because it was named
   incorrectly.There was an “s” missing from the word templates.
 
-.. _section-28:
+.. _section-29:
 
 `2.7.6 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.7.5...v2.7.6>`__ - 2024-11-12
 ---------------------------------------------------------------------------------------------------------
@@ -771,7 +831,7 @@ ADD
 
 - authentication_management module added
 
-.. _section-29:
+.. _section-30:
 
 `2.7.5 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.7.4...v2.7.5>`__ - 2024-11-11
 ---------------------------------------------------------------------------------------------------------
@@ -786,7 +846,7 @@ ADD
 - New Modules Such As (ai_endpoint_analytics,
   cisco_trusted_certificates, disaster_revery) were Added
 
-.. _section-30:
+.. _section-31:
 
 `2.7.4 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.7.3...v2.7.4>`__ - 2024-09-17
 ---------------------------------------------------------------------------------------------------------
@@ -794,7 +854,7 @@ ADD
 - Add multipart parameter for file upload in
   site_design:uploads_floor_image.
 
-.. _section-31:
+.. _section-32:
 
 `2.7.3 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.7.2...v2.7.3>`__ - 2024-08-19
 ---------------------------------------------------------------------------------------------------------
@@ -808,7 +868,7 @@ ADD
 - Update memberToTags from list to object in ``updates_tag_membership``
 - Update offset and limit parameter type to support int and str value
 
-.. _section-32:
+.. _section-33:
 
 `2.7.2 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.7.1...v2.7.2>`__ - 2024-08-09
 ---------------------------------------------------------------------------------------------------------
@@ -842,12 +902,12 @@ ADD
   - From delete_a_a_a_attribute_ap_i to delete_aaa_attribute_api
   - From get_a_a_a_attribute_ap_i to get_aaa_attribute_api
 
-.. _section-33:
+.. _section-34:
 
 `2.7.1 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.7.0...v2.7.1>`__ - 2024-05-31
 ---------------------------------------------------------------------------------------------------------
 
-.. _fixed-8:
+.. _fixed-9:
 
 Fixed
 ~~~~~
@@ -855,7 +915,7 @@ Fixed
 - Updated package version retrieval method from pkg_resources to
   importlib.metadata.
 
-.. _section-34:
+.. _section-35:
 
 `2.7.0 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.6.11...v2.7.0>`__ - 2024-05-31
 ----------------------------------------------------------------------------------------------------------
@@ -874,12 +934,12 @@ Added
 - Fix headers in ``create_webhook_destination`` and
   ``update_webhook_destination``
 
-.. _section-35:
+.. _section-36:
 
 `2.6.11 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.6.10...v2.6.11>`__ - 2023-01-10
 ------------------------------------------------------------------------------------------------------------
 
-.. _fixed-9:
+.. _fixed-10:
 
 Fixed
 ~~~~~
@@ -888,12 +948,12 @@ Fixed
   Fixing required schema.
 - Updating request version. Issue #132
 
-.. _section-36:
+.. _section-37:
 
 `2.6.10 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.6.9...v2.6.10>`__ - 2023-11-10
 -----------------------------------------------------------------------------------------------------------
 
-.. _fixed-10:
+.. _fixed-11:
 
 Fixed
 ~~~~~
@@ -902,7 +962,7 @@ Fixed
   ipInterfaceName
 - Fixed params in 2.3.5.3 claim_a_device_to_a_site from vlanID to vlanId
 
-.. _section-37:
+.. _section-38:
 
 `2.6.9 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.6.8...v2.6.9>`__ - 2023-09-20
 ---------------------------------------------------------------------------------------------------------
@@ -915,7 +975,7 @@ Changed
 - AP port assignment API not working with DNAC APIs of 2.3.3.0 #126,
   Documetion bug, extra-space in enum.
 
-.. _section-38:
+.. _section-39:
 
 `2.6.8 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.6.7...v2.6.8>`__ - 2023-09-12
 ---------------------------------------------------------------------------------------------------------
@@ -927,7 +987,7 @@ Changed
 
 - 2_3_3_0 sda sevice ``add_vn`` method update.
 
-.. _section-39:
+.. _section-40:
 
 `2.6.7 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.6.6...v2.6.7>`__ - 2023-08-25
 ---------------------------------------------------------------------------------------------------------
@@ -939,7 +999,7 @@ Changed
 
 - Update readthedocs settings
 
-.. _section-40:
+.. _section-41:
 
 `2.6.6 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.6.5...v2.6.6>`__ - 2023-07-10
 ---------------------------------------------------------------------------------------------------------
@@ -951,7 +1011,7 @@ Changed
 
 - Change requests-toolbelt minimum version #101
 
-.. _section-41:
+.. _section-42:
 
 `2.6.5 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.6.4...v2.6.5>`__ - 2023-05-29
 ---------------------------------------------------------------------------------------------------------
@@ -963,7 +1023,7 @@ Changed
 
 - user_and_roles::Unable to use user and roles module. #112
 
-.. _section-42:
+.. _section-43:
 
 `2.6.4 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.6.3...v2.6.4>`__ - 2023-05-25
 ---------------------------------------------------------------------------------------------------------
@@ -992,7 +1052,7 @@ Changed
 - Poor naming of function: v2_3_5_3/authentication_management.py :
   ``authentication_ap_i( #102``
 
-.. _section-43:
+.. _section-44:
 
 `2.6.3 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.6.2...v2.6.3>`__ - 2023-04-28
 ---------------------------------------------------------------------------------------------------------
@@ -1020,14 +1080,14 @@ Changed
 
   .. rubric:: `2.6.2 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.6.1...v2.6.2>`__
      - 2023-04-25
-     :name: section-44
+     :name: section-45
 
   .. rubric:: Changed
      :name: changed-13
 
 - Add ``issue`` family on 2.3.3.0
 
-.. _section-45:
+.. _section-46:
 
 `2.6.1 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.6.0...v2.6.1>`__ - 2023-04-12
 ---------------------------------------------------------------------------------------------------------
@@ -1041,7 +1101,7 @@ Changed
 - Correct families names in 2.3.5.3
 - Removing duplicate params
 
-.. _section-46:
+.. _section-47:
 
 `2.6.0 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.5.6...v2.6.0>`__ - 2023-04-12
 ---------------------------------------------------------------------------------------------------------
@@ -1054,7 +1114,7 @@ Added
 - Add support of DNA Center versions (‘2.3.5.3’)
 - Adds modules for v2_3_5_3
 
-.. _section-47:
+.. _section-48:
 
 `2.5.6 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.5.5...v2.5.6>`__ - 2023-01-10
 ---------------------------------------------------------------------------------------------------------
@@ -1066,7 +1126,7 @@ Added
 
 - Compatibility matrix added in ``readme.rst``
 
-.. _fixed-11:
+.. _fixed-12:
 
 Fixed
 ~~~~~
@@ -1093,12 +1153,12 @@ Fixed
   - dnacentersdk.api.v2_3_3_0.tag
   - dnacentersdk.api.v2_3_3_0.task
 
-.. _section-48:
+.. _section-49:
 
 `2.5.5 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.5.4...v2.5.5>`__ - 2022-11-17
 ---------------------------------------------------------------------------------------------------------
 
-.. _fixed-12:
+.. _fixed-13:
 
 Fixed
 ~~~~~
@@ -1110,7 +1170,7 @@ Fixed
 
 - Added Dict_of_str function call in custom_caller headers
 
-.. _section-49:
+.. _section-50:
 
 `2.5.4 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.5.3...v2.5.4>`__ - 2022-08-11
 ---------------------------------------------------------------------------------------------------------
@@ -1124,12 +1184,12 @@ Added
 
   - ``add_ssid_to_ip_pool_mapping``
 
-.. _section-50:
+.. _section-51:
 
 `2.5.3 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.5.2...v2.5.3>`__ - 2022-08-09
 ---------------------------------------------------------------------------------------------------------
 
-.. _fixed-13:
+.. _fixed-14:
 
 Fixed
 ~~~~~
@@ -1140,12 +1200,12 @@ Fixed
   ``connectedToInternet`` on ``sda.adds_border_device`` comes from
   ``boolean`` to ``string``.
 
-.. _section-51:
+.. _section-52:
 
 `2.5.2 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.5.1...v2.5.2>`__ - 2022-07-29
 ---------------------------------------------------------------------------------------------------------
 
-.. _fixed-14:
+.. _fixed-15:
 
 Fixed
 ~~~~~
@@ -1177,12 +1237,12 @@ Fixed
   - network
   - servers
 
-.. _section-52:
+.. _section-53:
 
 `2.5.1 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.5.0...v2.5.1>`__ - 2022-07-12
 ---------------------------------------------------------------------------------------------------------
 
-.. _fixed-15:
+.. _fixed-16:
 
 Fixed
 ~~~~~
@@ -1191,7 +1251,7 @@ Fixed
 
   - IpAddressSpace
 
-.. _section-53:
+.. _section-54:
 
 `2.5.0 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.4.11...v2.5.0>`__ - 2022-06-20
 ----------------------------------------------------------------------------------------------------------
@@ -1204,12 +1264,12 @@ Added
 - Add support of DNA Center versions (‘2.3.3.0’)
 - Adds modules for v2_3_3_0
 
-.. _section-54:
+.. _section-55:
 
 `2.4.11 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.4.10...v2.4.11>`__ - 2022-06-15
 ------------------------------------------------------------------------------------------------------------
 
-.. _fixed-16:
+.. _fixed-17:
 
 Fixed
 ~~~~~
@@ -1220,7 +1280,7 @@ Fixed
   - verify
   - debug
 
-.. _section-55:
+.. _section-56:
 
 `2.4.10 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.4.9...v2.4.10>`__ - 2022-05-12
 -----------------------------------------------------------------------------------------------------------
@@ -1236,7 +1296,7 @@ Added
 
   - site_name_hierarchy
 
-.. _section-56:
+.. _section-57:
 
 `2.4.9 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.4.8...v2.4.9>`__ - 2022-04-20
 ---------------------------------------------------------------------------------------------------------
@@ -1256,7 +1316,7 @@ Added
   - subnetMask
   - vlanId
 
-.. _section-57:
+.. _section-58:
 
 `2.4.8 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.4.7...v2.4.8>`__ - 2022-03-23
 ---------------------------------------------------------------------------------------------------------
@@ -1302,7 +1362,7 @@ Changed
   - dnacentersdk.api.v2_2_3_3.file.File.download_a_file_by_fileid
   - dnacentersdk.api.v2_2_3_3.reports.Reports.download_report_content
 
-.. _section-58:
+.. _section-59:
 
 `2.4.7 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.4.6...v2.4.7>`__ - 2022-03-22
 ---------------------------------------------------------------------------------------------------------
@@ -1315,7 +1375,7 @@ Added
 - Add ``rfProfile`` parameter for request body struct of
   ``claim_a_device_to_a_site``.
 
-.. _section-59:
+.. _section-60:
 
 `2.4.6 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.4.5...v2.4.6>`__ - 2022-03-14
 ---------------------------------------------------------------------------------------------------------
@@ -1346,7 +1406,7 @@ Changed
 
   - sda.adds_border_device
 
-.. _section-60:
+.. _section-61:
 
 `2.4.5 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.4.4...v2.4.5>`__ - 2022-02-01
 ---------------------------------------------------------------------------------------------------------
@@ -1372,7 +1432,7 @@ Changed
 
   - devices.sync_devices
 
-.. _section-61:
+.. _section-62:
 
 `2.4.4 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.4.3...v2.4.4>`__ - 2022-01-31
 ---------------------------------------------------------------------------------------------------------
@@ -1400,7 +1460,7 @@ Changed
   - site_design.update_floormap
   - application_policy.create_application
 
-.. _fixed-17:
+.. _fixed-18:
 
 Fixed
 ~~~~~
@@ -1416,12 +1476,12 @@ Added
 - Adds parameters ``hostname``, ``imageInfo`` and ``configInfo`` to
   device_onboarding_pnp.pnp_device_claim_to_site
 
-.. _section-62:
+.. _section-63:
 
 `2.4.3 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.4.2...v2.4.3>`__ - 2022-01-19
 ---------------------------------------------------------------------------------------------------------
 
-.. _fixed-18:
+.. _fixed-19:
 
 Fixed
 ~~~~~
@@ -1439,12 +1499,12 @@ Changed
   DNACenterAPI
 - Adds tests for env variables before/after DNACenterAPI import
 
-.. _section-63:
+.. _section-64:
 
 `2.4.2 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.4.1...v2.4.2>`__ - 2021-12-14
 ---------------------------------------------------------------------------------------------------------
 
-.. _fixed-19:
+.. _fixed-20:
 
 Fixed
 ~~~~~
@@ -1454,7 +1514,7 @@ Fixed
 - Update json schemas for models/validators and
   tests/models/models/validators
 
-.. _section-64:
+.. _section-65:
 
 `2.4.1 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.4.0...v2.4.1>`__ - 2021-12-01
 ---------------------------------------------------------------------------------------------------------
@@ -1466,7 +1526,7 @@ Changed
 
 - Update to match checksum
 
-.. _section-65:
+.. _section-66:
 
 `2.4.0 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.3.3...v2.4.0>`__ - 2021-12-01
 ---------------------------------------------------------------------------------------------------------
@@ -1497,7 +1557,7 @@ Changed
 
 - Update missing dnac 2.2.3.3 files
 
-.. _section-66:
+.. _section-67:
 
 `2.3.3 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.3.2...v2.3.3>`__ - 2021-11-24
 ---------------------------------------------------------------------------------------------------------
@@ -1529,7 +1589,7 @@ Changed
   - Add ``isGuestVirtualNetwork`` parameter to
     ``update_virtual_network_with_scalable_groups`` function
 
-.. _section-67:
+.. _section-68:
 
 `2.3.2 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.3.1...v2.3.2>`__ - 2021-09-14
 ---------------------------------------------------------------------------------------------------------
@@ -1541,12 +1601,12 @@ Changed
 
 - Disable verify=False warnings of urllib3
 
-.. _section-68:
+.. _section-69:
 
 `2.3.1 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.3.0...v2.3.1>`__ - 2021-08-10
 ---------------------------------------------------------------------------------------------------------
 
-.. _fixed-20:
+.. _fixed-21:
 
 Fixed
 ~~~~~
@@ -1554,7 +1614,7 @@ Fixed
 - Fix devices param definition & schemas [``aba32f3``]
 - Remove unnecesary path_params [``25c4e99``]
 
-.. _section-69:
+.. _section-70:
 
 `2.3.0 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.2.5...v2.3.0>`__ - 2021-08-09
 ---------------------------------------------------------------------------------------------------------
@@ -1579,7 +1639,7 @@ Changed
 - Updates restsession.py to handle downloads using Content-Disposition
   header rather than custom fileName header
 
-.. _section-70:
+.. _section-71:
 
 `2.2.5 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.2.4...v2.2.5>`__ - 2021-08-05
 ---------------------------------------------------------------------------------------------------------
@@ -1598,12 +1658,12 @@ Changed
 - Removes minus char from docstrings.
 - Adds check_type conditions for ‘X-Auth-Token’ for v2_2_1 operations.
 
-.. _section-71:
+.. _section-72:
 
 `2.2.4 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.2.3...v2.2.4>`__ - 2021-06-08
 ---------------------------------------------------------------------------------------------------------
 
-.. _fixed-21:
+.. _fixed-22:
 
 Fixed
 ~~~~~
@@ -1611,7 +1671,7 @@ Fixed
 - Fixes download_a_file_by_fileid and import_local_software_image for
   v2_2_1
 
-.. _section-72:
+.. _section-73:
 
 `2.2.3 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.2.2...v2.2.3>`__ - 2021-06-08
 ---------------------------------------------------------------------------------------------------------
@@ -1634,7 +1694,7 @@ Changed
 - Patch adds one function that was missing from previous release
 - Patch adds models/validators for v2_2_1 with new ids
 
-.. _section-73:
+.. _section-74:
 
 `2.2.2 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.0.2...v2.2.2>`__ - 2021-05-10
 ---------------------------------------------------------------------------------------------------------
@@ -1653,7 +1713,7 @@ Changed
 
 - Updates requirements files
 
-.. _section-74:
+.. _section-75:
 
 `2.0.2 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v2.0.0...v2.0.2>`__ - 2020-11-01
 ---------------------------------------------------------------------------------------------------------
@@ -1682,7 +1742,7 @@ Removed
 
 - Removed requirements.lock
 
-.. _section-75:
+.. _section-76:
 
 `2.0.0 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v1.3.0...v2.0.0>`__ - 2020-07-17
 ---------------------------------------------------------------------------------------------------------
@@ -1705,7 +1765,7 @@ Changed
 - Changed setup from versioneer to setuptools_scm
 - Changed version management to include patch (major, minor, patch)
 
-.. _fixed-22:
+.. _fixed-23:
 
 Fixed
 ~~~~~
@@ -1722,7 +1782,7 @@ Removed
 - Removed Webex Teams Space Community reference from README
 - Removed Token refresh when changing base_url
 
-.. _section-76:
+.. _section-77:
 
 `1.3.0 <https://github.com/cisco-en-programmability/dnacentersdk/compare/v1.2.10...v1.3.0>`__ - 2019-08-19
 ----------------------------------------------------------------------------------------------------------
@@ -1734,7 +1794,7 @@ Added
 
 - Add support for multiple versions of DNA Center (‘1.2.10’, ‘1.3.0’)
 
-.. _fixed-23:
+.. _fixed-24:
 
 Fixed
 ~~~~~
@@ -1743,7 +1803,7 @@ Fixed
 - Fix error in setter in ``api/__init__.py``
 - Fix errors for readthedocs
 
-.. _section-77:
+.. _section-78:
 
 `1.2.10 <https://github.com/cisco-en-programmability/dnacentersdk/releases/v1.2.10>`__ - 2019-07-18
 ---------------------------------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dnacentersdk"
-version = "2.11.2"
+version = "2.11.3"
 description = "Cisco DNA Center Platform SDK"
 authors = ["Jose Bogarin Solano <jbogarin@altus.cr>", "William Astorga <wastorga@altus.cr>", "Francisco Muñoz <fmunoz@altus.cr>", "Francisco Muñoz <fmunoz@altus.cr>", "Bryan Vargas <bvargas@altus.cr>"]
 license = "MIT"


### PR DESCRIPTION
…2.11.3)

- Fix missing dirpath/save_file/filename/stream params in download methods of configuration_archive v3.1.6.0 (#17 equivalent)
- Fix headers parameter collision in create/update_webhook_destination() — renamed payload field to webhook_headers across v2.3.5.3, v2.3.7.6, v2.3.7.9, v3.1.3.0, v3.1.6.0 (#20)
- Add udldGlobalConfig to create/update Layer2 wired methods and request validator schemas across v2.3.7.9, v3.1.3.0, v3.1.6.0 (#246)