### PR TITLE
Use Session to Retry Auth Errors with urllib

### DIFF
--- a/dnacentersdk/api/__init__.py
+++ b/dnacentersdk/api/__init__.py
@@ -563,6 +563,7 @@ class DNACenterAPI(object):
             object_factory,
             single_request_timeout=single_request_timeout,
             verify=verify,
+            session=session,
         )
 
         # Check if the user has provided the required basicAuth parameters

--- a/dnacentersdk/api/authentication.py
+++ b/dnacentersdk/api/authentication.py
@@ -54,7 +54,7 @@ class Authentication(object):
     """
 
     def __init__(
-        self, base_url, object_factory, single_request_timeout=None, verify=True
+        self, base_url, object_factory, single_request_timeout=None, verify=True, session=None
     ):
         """Initialize an Authentication
         object with the provided RestSession.
@@ -69,6 +69,8 @@ class Authentication(object):
             verify(bool,str): Controls whether we verify the server's
                 TLS certificate, or a string, in which case it must be a path
                 to a CA bundle to use.
+            session(requests.Session): Optionally inject a `requests.Session`
+                object to be used for HTTP operations.
 
         Raises:
             TypeError: If the parameter types are incorrect.
@@ -85,6 +87,9 @@ class Authentication(object):
         self._verify = verify
         self._request_kwargs = {"timeout": single_request_timeout, "verify": verify}
         self._object_factory = object_factory
+        
+        # Use the injected `requests` session, build a new one if not provided
+        self._session = session or requests.session()
 
         if verify is False:
             requests.packages.urllib3.disable_warnings()
@@ -156,23 +161,22 @@ class Authentication(object):
             check_type(encoded_auth, str, may_be_none=False)
             if isinstance(encoded_auth, str):
                 encoded_auth = bytes(encoded_auth, "utf-8")
-            # API request
-            response = requests.post(
-                self._endpoint_url,
-                data=None,
-                headers={"authorization": b"Basic " + encoded_auth},
-                **self._request_kwargs
-            )
+            request_headers = {"authorization": b"Basic " + encoded_auth}
+            request_auth = None
         else:
             check_type(username, str, may_be_none=False)
             check_type(password, str, may_be_none=False)
-            # API request
-            response = requests.post(
-                self._endpoint_url,
-                data=None,
-                auth=(username, password),
-                **self._request_kwargs
-            )
+            request_headers = None
+            request_auth = (username, password)
+
+        # API request using session (retries handled by urllib3.Retry configuration)
+        response = self._session.post(
+            self._endpoint_url,
+            data=None,
+            headers=request_headers,
+            auth=request_auth,
+            **self._request_kwargs
+        )
 
         check_response_code(response, EXPECTED_RESPONSE_CODE["POST"])
         json_data = extract_and_parse_json(response)

--- a/dnacentersdk/api/custom_caller.py
+++ b/dnacentersdk/api/custom_caller.py
@@ -129,6 +129,9 @@ class CustomCaller(object):
                 immediately downloaded.
             cert(str, tuple) (optional): if String, path to ssl client
                 cert file (.pem). If Tuple, (‘cert’, ‘key’) pair
+            expected_codes(list) (optional): List of acceptable HTTP response codes. 
+                If the response code is not in this list, an HTTPError will be raised 
+                if raise_exception is True. Defaults to 2xx status codes.
 
         Returns:
             MyDict or object: If original_response is True returns the
@@ -146,35 +149,50 @@ class CustomCaller(object):
 
         # Ensure the url is an absolute URL
         abs_url = self._session.abs_url(resource_path)
+        request_headers = kwargs.pop("headers", None)
         headers = self._session.headers
-
-        if "headers" in kwargs:
-            headers.update(kwargs.pop("headers"))
+        if request_headers:
+            headers.update(request_headers)
 
         verify = kwargs.pop("verify", self._session.verify)
-        if not self._session.authenticated:
-            logger.debug("Session not authenticated. Authenticating now.")
-            self._session.refresh_token()
-            
         logger.debug(pprint_request_info(abs_url, method, headers, **kwargs))
-        response = self._session._req_session.request(
-            method, abs_url, headers=headers, verify=verify, **kwargs
-        )
-        if response.status_code == 401:
-            logger.debug("Received 401 Unauthorized. Attempting to re-authenticate.")
-            self._session.refresh_token()
-            logger.debug("Retrying the API call after re-authentication.")
-            response = self._session._req_session.request(
-                method, abs_url, headers=headers, verify=verify, **kwargs
-            )
         
+        expected_codes = kwargs.pop("expected_codes", list(range(200, 300)))
 
+        request_kwargs = dict(kwargs)
+        if request_headers is not None:
+            request_kwargs["headers"] = request_headers
+        
         if raise_exception:
+            response = self._session.request(
+                method,
+                resource_path,
+                expected_codes,
+                0,
+                verify=verify,
+                **request_kwargs,
+            )
+        else:
+            # Catch SDK exceptions and return response anyway for compatibility
             try:
-                response.raise_for_status()
-            except HTTPError as e:
-                logger.debug(pprint_response_info(e.response))
-                raise e
+                response = self._session.request(
+                    method,
+                    resource_path,
+                    expected_codes,
+                    0,
+                    verify=verify,
+                    **request_kwargs,
+                )
+            except Exception:
+                # If RestSession raises an exception but user wants to suppress it,
+                # fall back to direct session call but ensure authentication
+                self._session._ensure_authenticated()
+                response = self._session.request(
+                    method,
+                    abs_url,
+                    verify=verify,
+                    **request_kwargs,
+                )
 
         logger.debug(pprint_response_info(response))
         if original_response:

--- a/tests/test_custom_caller.py
+++ b/tests/test_custom_caller.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+from unittest.mock import Mock
+
+from dnacentersdk.api.custom_caller import CustomCaller
+from dnacentersdk.restsession import RestSession
+
+
+class DummyResponse:
+    def __init__(self, status_code=200, text='{"ok": true}'):
+        self.status_code = status_code
+        self.text = text
+
+
+def _make_session():
+    token_calls = {"count": 0}
+
+    def _get_token():
+        token_calls["count"] += 1
+        return f"token-{token_calls['count']}"
+
+    session = RestSession(
+        get_access_token=_get_token,
+        base_url="https://example.com",
+        version="3.1.6.0",
+        user_agent="dnacentersdk",
+    )
+    session._ensure_authenticated()
+    return session
+
+
+def test_call_api_does_not_send_session_header_snapshot():
+    session = _make_session()
+    custom_caller = CustomCaller(session, lambda _name, payload: payload)
+
+    captured_kwargs = {}
+
+    def _request(method, path, expected_codes, custom_refresh, **kwargs):
+        captured_kwargs.update(kwargs)
+        return DummyResponse()
+
+    session.request = Mock(side_effect=_request)
+
+    result = custom_caller.call_api("GET", "/dna/intent/api/v1/network-device/count")
+
+    assert result["ok"] is True
+    assert "headers" not in captured_kwargs
+
+
+def test_call_api_passes_only_user_headers_when_provided():
+    session = _make_session()
+    custom_caller = CustomCaller(session, lambda _name, payload: payload)
+
+    captured_kwargs = {}
+
+    def _request(method, path, expected_codes, custom_refresh, **kwargs):
+        captured_kwargs.update(kwargs)
+        return DummyResponse()
+
+    session.request = Mock(side_effect=_request)
+
+    custom_caller.call_api(
+        "GET",
+        "/dna/intent/api/v1/network-device/count",
+        headers={"X-Custom": "value"},
+    )
+
+    assert captured_kwargs["headers"] == {"X-Custom": "value"}


### PR DESCRIPTION
As a Cisco Network Engineering and Operations engineer we are seeing issues with authorization because the dnacentersdk was not using a retry mechanism for the authorization API. This pull request makes two improvements:

 1, it changes code so that custom caller uses the RestSession Obj just like everything else and
 2, makes the Authorization class use a requests.Session obj so that user configured retries are used which reduces the likelyhood of automation code failing due to intermittent network issues.

This was tested internally both with dnacentersdk.Devices and with custom_caller and want to contribute this fix upstream so that everyone may benefit.

Thanks!
@zapodeanu and @wastorga 